### PR TITLE
Client scrape pipeline and source invites

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -21,6 +21,7 @@ COPY packages/interfaces/package.json ./packages/interfaces/
 COPY packages/agents/package.json ./packages/agents/
 COPY packages/connector/package.json ./packages/connector/
 COPY packages/logger/package.json ./packages/logger/
+COPY packages/scraper-core/package.json ./packages/scraper-core/
 
 # Create stub package.json for packages not needed by API but referenced in workspace
 RUN mkdir -p packages/workers packages/web packages/e2e && \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -18,6 +18,7 @@ COPY packages/workers/package.json ./packages/workers/
 COPY packages/connector/package.json ./packages/connector/
 COPY packages/web/package.json ./packages/web/
 COPY packages/e2e/package.json ./packages/e2e/
+COPY packages/scraper-core/package.json ./packages/scraper-core/
 RUN pnpm install --frozen-lockfile
 
 # ─── Stage 2: Build ──────────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       SQUARE_LOCATION_ID: ${SQUARE_LOCATION_ID:-}
       SQUARE_WEBHOOK_SIGNATURE_KEY: ${SQUARE_WEBHOOK_SIGNATURE_KEY:-}
       SQUARE_WEBHOOK_NOTIFICATION_URL: ${SQUARE_WEBHOOK_NOTIFICATION_URL:-}
-      # Credential encryption (for storing data-source login credentials)
+      # Credential encryption (for non-portal secrets, e.g. API tokens stored at rest)
       CREDENTIALS_ENCRYPTION_KEY: ${CREDENTIALS_ENCRYPTION_KEY:-dev-encryption-key-change-in-production}
       # AI (optional - for LLM material matching)
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
@@ -132,10 +132,9 @@ services:
       - /app/node_modules
       - /app/.next
 
-  # Workers (background jobs + browser scrapers)
+  # Workers (background jobs: analysis, notifications, digests)
   # Scale with: docker-compose up -d --scale workers=3
   # Each instance competes for jobs via atomic MongoQueue — no double-processing.
-  # NOTE: Build with ./scripts/build-workers.sh first (copies scrapers into context).
   workers:
     image: scholaracle-workers:latest
     restart: unless-stopped
@@ -163,12 +162,9 @@ services:
       SKIP_FIREBASE: ${SKIP_FIREBASE:-true}
       # AI (optional - for digest insights)
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      # Scraping concurrency (Chromium instances per worker container)
-      # Each browser uses ~300-500MB RAM. With 2GB limit, max ~3 concurrent.
+      # Sync job concurrency (how many jobs workers process in parallel)
       SYNC_CONCURRENCY: ${SYNC_CONCURRENCY:-2}
       SYNC_POLL_INTERVAL_MS: ${SYNC_POLL_INTERVAL_MS:-5000}
-      # Playwright
-      PLAYWRIGHT_BROWSERS_PATH: /root/.cache/ms-playwright
     depends_on:
       mongodb:
         condition: service_healthy
@@ -180,7 +176,7 @@ services:
       start_period: 30s
     networks:
       - scholaracle-network
-    # Resource limits per instance (Playwright Chromium is memory-hungry)
+    # Resource limits per instance
     deploy:
       resources:
         limits:

--- a/docs/CLIENT_PIPELINE_SPEC.md
+++ b/docs/CLIENT_PIPELINE_SPEC.md
@@ -1,0 +1,583 @@
+# Client Scraper Pipeline — Engineering Specification
+
+**Status**: v1.0 — approved for implementation  
+**Applies to**: `scraper-core`, `scraper-playwright`, `mobile`, `browser-extension`, `scholaracle_scrapers`  
+**Cross-reference**: [CLIENT_SCRAPER_SPEC.md](./CLIENT_SCRAPER_SPEC.md) for data quality rules (identity, join keys, completeness)
+
+---
+
+## 1. Goal
+
+Every client (mobile app, browser extension, CLI) currently contains a duplicated
+`switch(provider)` orchestrator, independent envelope assembly, and inconsistent ingest
+URL paths. The target is **one orchestrator** that all three clients call as a pure
+host-injection pattern:
+
+```
+Client (host provider)
+  └─ scraper-core: runClientScrape(host) → ISlcIngestEnvelopeV1
+       ├─ resolves IScraperModule by provider
+       ├─ calls module.scrape(host) → raw extract
+       ├─ calls module.transform(raw, ctx) → ISlcDeltaOp[]
+       ├─ calls validateEnvelope
+       └─ calls host.uploader.uploadRun (three-step protocol)
+```
+
+Authentication (login) stays in the client because it is always runtime-specific.
+After a successful login the client hands a live `IPageDriver` to `runClientScrape`.
+
+---
+
+## 2. `IClientScrapeHost` interface
+
+```typescript
+// scraper-core/src/pipeline/types.ts
+
+export type ClientType = 'mobile' | 'browser-extension' | 'cli';
+
+export interface IClientScrapeConfig {
+  /** Provider key: 'canvas' | 'skyward' | 'aeries' | ... */
+  readonly provider: string;
+  readonly adapterId: string;
+  readonly adapterVersion: string;
+  readonly baseUrl: string;
+  readonly sourceId: string;
+  readonly studentExternalId: string;
+  readonly institutionExternalId: string;
+  readonly studentNameHint?: string;
+  /** scraper-core semver string (injected by build tooling). */
+  readonly coreVersion?: string;
+}
+
+export interface IIngestUploader {
+  /** POST /api/ingest/v1/runs */
+  registerRun(params: IRegisterRunParams): Promise<void>;
+  /** POST /api/ingest/v1/runs/:runId/envelope */
+  uploadEnvelope(runId: string, envelope: ISlcIngestEnvelopeV1): Promise<void>;
+  /** POST /api/ingest/v1/runs/:runId/complete */
+  completeRun(runId: string, status: 'success' | 'failed', error?: string): Promise<void>;
+}
+
+export interface IRegisterRunParams {
+  readonly runId: string;
+  readonly provider: string;
+  readonly adapterId: string;
+  readonly sourceId: string;
+  readonly startedAt: string;
+}
+
+export interface IClientScrapeHost {
+  /** Live, authenticated page driver handed to the module's scrape() call. */
+  readonly driver: IPageDriver;
+  /** Resolved config for this run. */
+  readonly config: IClientScrapeConfig;
+  /** Client type used in envelope meta and progress messages. */
+  readonly clientType: ClientType;
+  /** Three-step ingest uploader. */
+  readonly uploader: IIngestUploader;
+  /**
+   * Optional asset host. When present the pipeline calls it before upload so
+   * that local files or in-page base64 blobs are processed and URLs rewritten.
+   * Omit on mobile/extension (handled in-page via base64 embedding).
+   */
+  readonly assets?: IAssetHost;
+  /**
+   * Optional run recorder for local persistence of sync history
+   * (mobile/CLI only; extension can omit).
+   */
+  readonly recorder?: IRunRecorder;
+  /** Emit progress events back to the caller UI. */
+  onProgress?(progress: ISyncProgress): void;
+  /**
+   * Optional extra enricher (LLM / API / on-device). Always runs after the
+   * built-in JoinGapEnricher. Fail-open — see §2.2.
+   */
+  readonly enricher?: IAIEnricher;
+  readonly enricherTimeoutMs?: number;
+  /** Optional resolver override (tests / sideload). */
+  readonly resolver?: IScraperResolver;
+}
+```
+
+### 2.2 `IAIEnricher` — fail-open join intelligence
+
+```typescript
+export interface IAIEnricher {
+  enrich(rawExtract: Record<string, unknown>, ops: ISlcDeltaOp[]): Promise<ISlcDeltaOp[]>;
+}
+```
+
+`runClientScrape` **always** runs `JoinGapEnricher` (deterministic, no LLM) after
+transform/assets, then `host.enricher` if present. Mobile, extension, and CLI
+therefore get join fills with **no signature change**.
+
+| Allowed fills (empty fields only) | Forbidden |
+|-----------------------------------|-----------|
+| `record.courseExternalId`         | New ops, dropped ops |
+| `record.assignmentExternalId`     | Changing `key.externalId` |
+| `record.courseName`               | Overwriting a non-empty field |
+| `key.courseExternalId` if empty   | FKs that do not already exist in this envelope |
+|                                   | Raw HTML, cookies, passwords |
+
+Illegal patches, throws, and timeouts are discarded. The original (or last legal)
+ops continue. Envelope `run.meta` records `enrichmentSource`, `enrichmentPatchCount`,
+`enrichmentFailed`.
+
+### 2.3 Server ingest enrichment (`ENRICH_OPS_MODE`)
+
+`POST /api/ingest/v1/runs/:runId/envelope` runs the **same** `JoinGapEnricher`
+after schema validation and before `applyOps`. This covers old TestFlight
+builds, CLI, and any client that does not yet run the client-side enricher.
+
+| `ENRICH_OPS_MODE` | Behaviour |
+|-------------------|-----------|
+| `off` (default) | Identity. Production-safe. |
+| `shadow` | Enrich and log `enrichPatchCount`; persist **original** ops. |
+| `apply` | Enrich, revalidate, persist enriched ops. On failure, persist original ops. |
+
+Inject `enrichOpsMode` on `IIngestV1RouterConfig` in tests instead of mutating env.
+JoinGap is idempotent: a client that already filled FKs yields `patchCount: 0`.
+
+Adaptive HTML fallback is out of scope.
+
+### 2.1 `IIngestUploader` — canonical three-step paths
+
+All three clients MUST use these paths:
+
+| Step | Path | Notes |
+|------|------|-------|
+| 1. Register | `POST /api/ingest/v1/runs` | Body: `IRegisterRunParams` |
+| 2. Upload | `POST /api/ingest/v1/runs/:runId/envelope` | Body: full `ISlcIngestEnvelopeV1` |
+| 3. Complete | `POST /api/ingest/v1/runs/:runId/complete` | Body: `{ runId, status }` |
+
+> **Extension drift (fix required):** `ingest.ts` currently calls `/api/ingest/v1/envelope`
+> and `/api/ingest/v1/complete` (without `:runId`). These are wrong. After this spec is
+> implemented the extension's `IIngestUploader` implementation must use the paths above.
+
+---
+
+## 3. `runClientScrape` function
+
+```typescript
+// scraper-core/src/pipeline/runClientScrape.ts
+
+export async function runClientScrape(
+  host: IClientScrapeHost
+): Promise<ISlcIngestEnvelopeV1>
+```
+
+### 3.1 Pipeline steps
+
+```
+1. Generate runId (UUID)
+2. resolver.resolve(provider) → IScraperModule
+3. host.recorder?.startRun(...)        [optional]
+4. emit 'extracting'
+5. module.scrape(host)                  → raw extract    [portal step]
+6. emit 'transforming'
+7. module.transform(raw, ctx)           → ISlcDeltaOp[]  [local step]
+8. host.assets?.processOps(ops)         → ops′           [optional, CLI only]
+8b. JoinGapEnricher then host.enricher?  → ops″          [fail-open; never throws]
+9. assemble ISlcIngestEnvelopeV1
+10. validateEnvelope(envelope)          [throw on hard errors; warn on completeness]
+11. emit 'uploading'
+12. uploader.registerRun(...)
+13. uploader.uploadEnvelope(runId, envelope)
+14. uploader.completeRun(runId, 'success')
+15. host.recorder?.completeRun(...)     [optional]
+16. emit 'complete'
+17. return envelope
+```
+
+Any exception in steps 5 throws as `SyncError { phase: 'portal' }`.  
+Any exception in steps 7–10 throws as `SyncError { phase: 'local' }`.  
+Any exception in steps 12–14 throws as `SyncError { phase: 'upload' }`.
+
+### 3.2 `IScraperModule` — builtin implementations
+
+Each builtin module wraps the existing recipe + transformer pair:
+
+```typescript
+// canvasBuiltinModule (already exists; MUST be updated for native IDs per §6)
+export const canvasBuiltinModule: IScraperModule = {
+  metadata: { adapterId: 'canvas-lms', ... },
+  async scrape(host) { return runCanvasRecipe(host.driver, host.config.baseUrl); },
+  transform(raw, ctx)  { return transformCanvasExtract(raw as ICanvasBrowserExtract, ctx); },
+};
+
+export const skywardBuiltinModule: IScraperModule = { ... };
+export const aeriesBuiltinModule:  IScraperModule = { ... };
+```
+
+`BuiltinScraperResolver.resolve(provider)` maps `canvas → canvasBuiltinModule` etc.
+This resolver is already exported from `scraper-core/src/registry`.
+
+### 3.3 Envelope `meta` shape
+
+The `run.meta` block tells the server which client produced the envelope:
+
+| field | mobile | extension | CLI |
+|-------|--------|-----------|-----|
+| `clientType` | `'mobile'` | `'browser-extension'` | `'cli'` |
+| `coreVersion` | package.json injected | same | same |
+| `adapterVersion` | `IClientScrapeConfig.adapterVersion` | same | same |
+| `platform` | `'ios'` / `'android'` | omit | `'node'` |
+| `extensionVersion` | omit | extension manifest version | omit |
+
+---
+
+## 4. Driver contract (`IPageDriver`)
+
+The driver interface is defined in `scraper-core/src/driver/IPageDriver.ts`.
+Below are the exact semantics each host implementation MUST honour.
+
+### 4.1 `evaluate<TArgs, TResult>(fn, ...args)`
+
+- `fn` is a self-contained function with **no outer-scope closure** (same browser-context restriction as `page.evaluate`).
+- Callers MUST pass at most **one positional argument** after `fn`. Multi-value inputs MUST be packed into a single object/array:
+
+```typescript
+// CORRECT
+await driver.evaluate(myExtractFn, { courseId, baseUrl });
+
+// WRONG — forbidden, Playwright only forwards the first extra arg
+await driver.evaluate(extractSkywardCourseAssignments, course.name, course.period);
+```
+
+All extractors with multiple current parameters (`extractSkywardCourseAssignments`,
+`extractAeriesCourseAssignments`) MUST be updated to accept a single options object
+before this spec is fully implemented (see §7).
+
+### 4.2 `goto(url, options?)`
+
+- `options.waitUntil`:
+  - `'load'` (default) — wait for the load event only. Use when the SPA may hold long-poll connections.
+  - `'networkidle'` — wait until no network activity for 500 ms. Use only for login confirmation and first-load.
+- Recipes MUST prefer `'load'` for course-page navigation inside loops to avoid timeouts.
+- Caller may pass `options.timeout` (ms); recipe is responsible for reasonable defaults (30 000 ms or less).
+
+### 4.3 `onNewPage(handler)`
+
+Called once during `initialize` or at the start of `scrape`. Required for Skyward's popup pattern.
+
+- The handler receives a new `IPageDriver` wrapping the popup page.
+- After the handler resolves the **host driver instance** MUST redirect all subsequent calls to the popup page.
+- Playwright: already implemented via `context.on('page', ...)` + `setPage()`.
+- Extension `ContentScriptPageDriver`: popup windows open in a new tab; the content script cannot follow. **Skyward is therefore degraded on the extension** — `onNewPage` MUST log a warning and the recipe MUST fall back to no-popup login detection (password form in the main window, not a popup). If a popup is detected the scrape MUST fail fast with a user-friendly error message: `"Skyward opened a popup window. Open the Skyward tab that appeared and retry sync from there."`
+- Mobile `WebViewPageDriver`: in-app WebView cannot open popups; same degraded behaviour applies.
+
+### 4.4 `waitForLoad(options?)`
+
+Silently swallows timeouts (`.catch(() => {})`). Recipes MUST NOT rely on it resolving without error.
+
+### 4.5 `sleep(ms)`
+
+Convenience wrapper around the runtime's pause mechanism. Recipes SHOULD use it sparingly (prefer `waitForLoad` or `waitForUrlIncludes` when the completion signal exists).
+
+---
+
+## 5. Client host implementations
+
+### 5.1 Mobile (`SyncOrchestrator`)
+
+After this change `SyncOrchestrator.ts` becomes a thin host builder:
+
+```typescript
+import { runClientScrape, BuiltinScraperResolver } from '@scholaracle/scraper-core';
+
+export async function runSyncPipeline(
+  driver: IPageDriver,
+  config: ISyncOrchestratorConfig,
+  uploader: IEnvelopeUploader,
+  connectorToken: string,
+  recorder: IRunRecorder,
+  onProgress?: SyncProgressCallback
+): Promise<ISlcIngestEnvelopeV1> {
+  return runClientScrape({
+    driver,
+    config: { ...config, coreVersion: SCRAPER_CORE_PACKAGE_VERSION },
+    clientType: 'mobile',
+    uploader: buildMobileUploader(uploader, connectorToken),
+    recorder,
+    onProgress,
+  });
+}
+```
+
+The `buildMobileUploader` adapts `IEnvelopeUploader` (existing interface) to `IIngestUploader`
+without changing the rest of the mobile codebase.
+
+### 5.2 Browser extension (`content-script.ts`)
+
+```typescript
+import { runClientScrape, BuiltinScraperResolver } from '@scholaracle/scraper-core';
+import { ExtensionIngestUploader } from '../lib/ingest';
+
+async function runSync(msg: IRunSyncMessage): Promise<void> {
+  const { runId, credential, connectorToken, apiBaseUrl } = msg;
+  const driver = new ContentScriptPageDriver();
+
+  const envelope = await runClientScrape({
+    driver,
+    config: { runId, ...credentialToConfig(credential) },
+    clientType: 'browser-extension',
+    uploader: new ExtensionIngestUploader(apiBaseUrl, connectorToken),
+    onProgress: (p) => chrome.runtime.sendMessage({ type: 'SYNC_PROGRESS', ...p }),
+  });
+
+  chrome.runtime.sendMessage({ type: 'SYNC_COMPLETE', runId, opCount: envelope.ops.length });
+}
+```
+
+`ExtensionIngestUploader` MUST use the canonical three-step paths (see §2.1).
+
+### 5.3 CLI (`BaseScraper`)
+
+`BaseScraper` currently orchestrates: authenticate → scrape → transform → validate → upload.
+After this change `scrape()` and `transform()` are called through `runClientScrape` via an
+`IScraperModule` adapter:
+
+```typescript
+// CLI: each platform scraper remains responsible for authenticate() only.
+// After login it calls:
+const envelope = await runClientScrape({
+  driver: this.driver,
+  config: { ...this.config, coreVersion: SCRAPER_CORE_PACKAGE_VERSION },
+  clientType: 'cli',
+  uploader: new CliIngestUploader(this.config.apiBaseUrl, this.config.connectorToken),
+  assets: this.config.assetHost,
+  recorder: this.config.recorder,
+  onProgress: (p) => this.emitProgress(p.phase, p.message),
+});
+```
+
+`CliIngestUploader` is a simple `fetch`-based implementation of `IIngestUploader`.
+
+#### 5.3.1 Playwright driver consolidation
+
+`scholaracle_scrapers/src/core/playwright-driver.ts` is **functionally equivalent** to
+`@scholaracle/scraper-playwright/src/playwright-driver.ts` and both implement `IPageDriver`.
+They cannot be merged into a single npm package today because the CLI uses
+`playwright@^1.48` while the monorepo uses `playwright@^1.62` — the types are binary
+incompatible at the TypeScript level.
+
+**Until playwright is pinned to the same version across both repos**, the CLI MUST keep its
+own `src/core/playwright-driver.ts`. It MUST implement `IPageDriver` from
+`@scholaracle/scraper-core` and MUST NOT duplicate the `IPageDriver` interface itself.
+When the playwright versions are aligned, `src/core/playwright-driver.ts` should be
+deleted and the CLI should import `PlaywrightPageDriver` from `@scholaracle/scraper-playwright`.
+
+#### 5.3.2 Dead transformer/validator forks
+
+Any local `*-transformer.ts` or `*-validator.ts` files under `scholaracle_scrapers/src/`
+that re-export or duplicate code from `@scholaracle/scraper-core` MUST be deleted.
+Scrapers import directly from `@scholaracle/scraper-core`.
+
+---
+
+## 6. Native and stable `externalId` rules (per-platform)
+
+See [CLIENT_SCRAPER_SPEC.md §3](./CLIENT_SCRAPER_SPEC.md) for the full identity contract.
+This section specifies the concrete IDs transformers MUST emit.
+
+### 6.1 Canvas
+
+| Entity | Current (wrong) | Required |
+|--------|----------------|---------|
+| `assignment` | `canvas-${courseId}-assignment-${arrayIndex}` | `canvas-assignment-${nativeId}` where `nativeId = a.id` from Canvas API |
+| `courseMaterial` (file) | `canvas-file-${courseId}-${fileName}` | `canvas-file-${nativeFileId}` where `nativeFileId = file.id` from Canvas API |
+| `message` (announcement) | `canvas-announcement-${arrayIndex}` | `canvas-announcement-${ann.id}` — requires adding `id` field to extractor |
+| `teacher` | `canvas-teacher-${tid}` | keep (tid is already the Canvas API native user ID) |
+| `course` | `canvas-course-${courseId}` | keep |
+| `gradeSnapshot` | `canvas-grade-${courseId}` | keep |
+| `academicTerm` | `canvas-term-fall/spring-${year}` | `canvas-term-${raw.term.id}` when Canvas term object has an ID; fall back to `canvas-term-${slugify(termName)}` |
+
+**`matchMaterialsToAssignments`** MUST be updated to return a `Map<fileId, assignmentNativeId>`
+instead of `Map<fileName, assignmentArrayIndex>`. The transformer then uses `canvas-assignment-${nativeId}` as `assignmentExternalId`.
+
+### 6.2 Skyward
+
+| Entity | Current (wrong) | Required |
+|--------|----------------|---------|
+| `course` | `skyward-course-${period}-${slugify(name)}` | `skyward-course-${_cni}` when `_cni` is present; fall back to `skyward-course-${period}-${slugify(name)}` |
+| `assignment` (missing) | `skyward-missing-${slugify(title)}-${period}-${date}` | `skyward-assign-${period}-${slugify(title)}-${date}` (unified prefix) |
+| `assignment` (graded) | `skyward-assign-${period}-${slugify(title)}-${date}` | same (already composite + stable) |
+| `gradeSnapshot` | `skyward-grade-${period}-${slugify(name)}` | `skyward-grade-${_cni}` when `_cni` present |
+
+**`_cni`** is the Skyward section ID field already captured by the recipe (`sectionId.split('_')[1]`).
+Transformers MUST use it when non-empty.
+
+**Hardcoded LDISD term calendar**: the term definitions in `skyward-transformer.ts` are
+district-specific. The recipe MUST be updated to extract the grading period header labels and
+date ranges from the gradebook HTML. The transformer then receives the actual term definitions
+in the extract rather than relying on a hardcoded constant. Until that recipe work is done the
+hardcoded calendar remains acceptable for the LDISD deployment.
+
+### 6.3 Aeries
+
+| Entity | Current (wrong) | Required |
+|--------|----------------|---------|
+| `course` | `aeries-course-${studentId}-${arrayIndex}-${name}` | `aeries-course-${studentId}-${period}-${slugify(name)}` |
+| `assignment` | `aeries-${courseExtId}-assignment-${arrayIndex}` | `aeries-assign-${studentId}-${period}-${a.number}` where `a.number` is the assignment number from the Aeries gradebook |
+| `gradeSnapshot` | `aeries-grade-${courseExtId}` | `aeries-grade-${studentId}-${period}-${slugify(courseName)}` |
+| `attendanceEvent` | `aeries-attendance-${studentId}-${arrayIndex}-${date}` | `aeries-attend-${studentId}-${parseDate(att.date)}-${att.period}` |
+
+---
+
+## 7. Extractor evaluate contract — single-arg rule
+
+All extractor functions exposed via `driver.evaluate()` MUST accept at most one argument:
+
+### Functions requiring update
+
+| Extractor | Current signature | New signature |
+|-----------|------------------|---------------|
+| `extractSkywardCourseAssignments` | `(courseName: string, period: string)` | `(opts: { courseName: string; period: string })` |
+| `extractAeriesCourseAssignments` | `(courseIndex: number, studentSelector: string)` | `(opts: { courseIndex: number; studentSelector: string })` |
+
+All call sites in `skyward-recipe.ts` and `aeries-recipe.ts` MUST be updated to pass the single object.
+
+---
+
+## 8. Four-pictures gap fills (recipe completions)
+
+The following data points are defined in `CLIENT_SCRAPER_SPEC.md` but not yet extracted:
+
+### 8.1 Canvas
+
+| Gap | Action |
+|-----|--------|
+| Announcement body | Add `message` field to `fetchCanvasAnnouncements` fetch; add `body?: string` to `ICanvasBrowserAnnouncement`; emit body in transformer |
+| Canvas native term | `fetchCanvasCourses` already returns `term?: { id, name }` — use `term.id` for `termExternalId` where available; fall back to inferred semester |
+| Events → `eventSeries` ops | `upcomingEvents` are extracted but not transformed. Emit as `scheduledEvent` ops keyed `canvas-event-${hash(title+date)}` |
+| To-do items | Currently extracted but not transformed. Emit as `assignment` with `status: 'not_started'` keyed by `canvas-todo-${hash(title+course)}` |
+
+### 8.2 Skyward
+
+| Gap | Action |
+|-----|--------|
+| Teacher ops | Schedule entries carry `teacher` name — emit `teacher` ops keyed `skyward-teacher-${period}-${slugify(teacher)}` |
+| Dynamic terms | Scrape visible grade period column headers from gradebook HTML; store in `ISkywardFullExtract.termDefs[]`; transformer uses these instead of hardcoded calendar |
+| Attendance `courseExternalId` | Match attendance period to course period; emit `courseExternalId` on `attendanceEvent` |
+
+### 8.3 Aeries
+
+| Gap | Action |
+|-----|--------|
+| `academicTerm` ops | Extract term labels from the course term field (`IAeriesCourseExtract.term`); emit `academicTerm` ops |
+| Teacher ops | `IAeriesCourseExtract` has `teacher` + `teacherEmail` — emit `teacher` ops keyed `aeries-teacher-${slugify(teacher)}` |
+| Attendance `courseExternalId` | Match attendance `period` to `IAeriesCourseExtract.period`; emit `courseExternalId` |
+
+---
+
+## 9. Asset pipeline (`IAssetHost`)
+
+Asset processing (download → S3 upload → URL rewrite) is CLI-only.
+The interface MUST be defined in `scraper-core` so all clients can reference the type,
+but implementations live outside of `scraper-core`.
+
+```typescript
+// scraper-core/src/pipeline/types.ts
+
+export interface IAssetHost {
+  /**
+   * Given a list of ops that may contain local file paths or temporary URLs,
+   * downloads assets, uploads to permanent storage, and rewrites the URLs in-place.
+   * Returns the mutated ops array.
+   * No-ops silently when the host is absent (mobile/extension).
+   */
+  processOps(ops: ISlcDeltaOp[]): Promise<ISlcDeltaOp[]>;
+}
+```
+
+The CLI's `BaseScraper` asset pipeline becomes an `IAssetHost` implementation.
+Mobile and extension omit `assets` from the host; `runClientScrape` skips the step.
+
+---
+
+## 10. API scraper module (`IApiScraperModule`)
+
+Google Classroom and OneRoster do not require a browser. They authenticate via OAuth tokens
+the device already holds (Google account session on mobile, stored token in the extension).
+
+These providers MUST NOT be implemented as `IScraperModule` (which requires `IPageDriver`).
+Instead they implement `IApiScraperModule`:
+
+```typescript
+// scraper-core/src/pipeline/types.ts
+
+export interface IApiScraperModule {
+  readonly metadata: IScraperManifest;
+  /** No driver needed — performs REST calls directly. */
+  scrape(config: IClientScrapeConfig): Promise<Record<string, unknown>>;
+  transform(raw: Record<string, unknown>, ctx: ITransformContext): ISlcDeltaOp[];
+}
+```
+
+`runClientScrape` detects `IApiScraperModule` by duck-typing (`'scrape' in module && fn.length === 1`)
+and skips `host.driver` injection entirely.
+
+Classroom implementation scope is deferred (see todo `later-assets-classroom`).
+
+---
+
+## 11. `IRunRecorder` contract (unchanged)
+
+The existing `IRunRecorder` interface from mobile remains the spec for run-recording:
+
+```typescript
+interface IRunRecorder {
+  startRun(params: IStartRunParams): Promise<void>;
+  addPhase(runId: string, phase: IPhaseRecord): Promise<void>;
+  completeRun(runId: string, result: IRunResult): Promise<void>;
+}
+```
+
+Extension and CLI may pass `undefined` for `host.recorder`; `runClientScrape` skips all
+recorder calls when it is absent.
+
+---
+
+## 12. Dependency topology
+
+```
+scraper-core       (no runtime deps — only @scholaracle/contracts)
+  └─ IPageDriver, IClientScrapeHost, IAssetHost, IApiScraperModule
+  └─ runClientScrape, builtin modules, validator
+
+scraper-playwright (depends on scraper-core + playwright)
+  └─ PlaywrightPageDriver, createPlaywrightDriver
+
+scholaracle_scrapers (CLI; depends on scraper-core + scraper-playwright)
+  └─ Platform scrapers: authenticate() → then calls runClientScrape
+  └─ CliIngestUploader, CliAssetHost
+
+packages/mobile (Expo; depends on scraper-core)
+  └─ WebViewPageDriver, MobileIngestUploader
+  └─ SyncOrchestrator: runSyncPipeline() calls runClientScrape
+
+packages/browser-extension (Chrome MV3; depends on scraper-core)
+  └─ ContentScriptPageDriver, ExtensionIngestUploader
+  └─ content-script: runSync() calls runClientScrape
+```
+
+`scraper-playwright` MUST NOT be imported by `mobile` or `browser-extension`.
+
+---
+
+## 13. Migration checklist
+
+- [x] Add `IClientScrapeHost`, `IIngestUploader`, `IAssetHost`, `IApiScraperModule` to `scraper-core/src/pipeline/types.ts`
+- [x] Implement `runClientScrape` in `scraper-core/src/pipeline/runClientScrape.ts`
+- [x] Export new symbols from `scraper-core/src/index.ts`
+- [ ] Fix extractor single-arg rule (§7): `extractSkywardCourseAssignments`, `extractAeriesCourseAssignments`
+- [x] Fix extension ingest URLs to use canonical three-step paths (§2.1) — `ExtensionIngestUploader` in `browser-extension/src/lib/ingest.ts`
+- [x] Update `SyncOrchestrator.runSyncPipeline` to delegate to `runClientScrape` (§5.1)
+- [x] Update `content-script.ts` to delegate to `runClientScrape` (§5.2)
+- [x] Delete CLI transformer forks (`canvas-transformer.ts`, `skyward-transformer.ts`, `aeries-transformer.ts`); update test imports to `@scholaracle/scraper-core` (§5.3)
+- [x] Delete CLI `validator.ts` fork; update all callers to import from `@scholaracle/scraper-core` (§5.3)
+- [x] Add `IAIEnricher` + fail-open `JoinGapEnricher` in `runClientScrape` (always on; host enricher optional)
+- [x] Server ingest `prepareIngestOps` behind `ENRICH_OPS_MODE` (`off` / `shadow` / `apply`; default `off`)
+- [ ] Optional `IAssetHost` for CLI vs in-page base64; Classroom as `IApiScraperModule`
+- [ ] Playwright driver consolidation deferred: version mismatch between CLI (`^1.48`) and monorepo (`^1.62`) — see §5.3.1
+- [ ] Add `IApiScraperModule` type (§10) — implementation deferred

--- a/docs/CLIENT_SCRAPER_SPEC.md
+++ b/docs/CLIENT_SCRAPER_SPEC.md
@@ -1,0 +1,382 @@
+# Client Scraper Specification
+
+> Version 1.0 — 2026-08-14
+>
+> Authoritative contract for **every client scraper** (iOS WebView, browser
+> extension, local CLI). The server never logs into school portals. Clients
+> extract, normalize into `ISlcIngestEnvelopeV1`, and upload. The server
+> stores the envelope, generates alerts, and runs **join intelligence**
+> across subjects, grades, and resources.
+>
+> Field-level catalog: [`DATA_EXTRACTION_CHECKLIST.md`](./DATA_EXTRACTION_CHECKLIST.md)
+> Envelope types: `packages/contracts/src/models/Ingest.ts`
+
+---
+
+## 1. What a client scraper is for
+
+```
+School portal  --login+extract-->  Client device  --envelope only-->  Scholaracle API
+                                                                  |
+                                                                  v
+                                                            Workers (alerts, digest)
+```
+
+| Client | Runtime | Credentials live in |
+|--------|---------|---------------------|
+| iOS app | WebView + `SyncOrchestrator` | Keychain |
+| Browser extension | Content script | `chrome.storage.local` |
+| Local CLI (`scholaracle-scraper`) | Playwright on the user's machine | Local config file |
+
+All three **must** produce the same envelope shape, pass the same validator,
+and emit the same join keys. Transformers in `@scholaracle/scraper-core` are
+the shared implementation; custom CLI scrapers must still satisfy this spec.
+
+The server does **not** scrape, decrypt portal passwords, or fetch Classroom
+APIs. If a join cannot be made, it is because the envelope lacked keys or
+hints — not because the server should have logged in.
+
+---
+
+## 2. The product needs four pictures
+
+A complete student view is four joined pictures, not a pile of rows.
+
+| Picture | Built from | Authoritative source |
+|---------|------------|----------------------|
+| **Who / where** | `studentProfile`, `institution`, `academicTerm`, `teacher` | Any |
+| **Official grades** | `gradeSnapshot` + `course` | SIS (Skyward, Aeries) |
+| **What is due / missing** | `assignment` | LMS (Canvas, Classroom) first; SIS fills graded/missing |
+| **What to study with** | `courseMaterial` linked to course **and** assignment | LMS files, modules, attachments |
+
+Join intelligence exists so that:
+
+- Skyward `"ALGEBRA 1"` and Canvas `"algebra🔢"` become **one subject**.
+- A Canvas file `"5.A Independent Practice.pdf"` attaches to assignment
+  `"5.A - Independent Practice"` in that course.
+- The **Skyward percent** is the grade shown; Canvas assignments still drive
+  the action board.
+
+If the envelope omits join keys, intelligence cannot invent them.
+
+---
+
+## 3. Identity rules (MUST)
+
+Every upsert op has `key = { provider, adapterId, externalId, … }`.
+
+1. **`externalId` is stable across runs.** Re-scraping the same portal object
+   must produce the same `externalId`. The ingest pipeline upserts on
+   `(provider, adapterId, externalId)`.
+2. **Prefer the platform's native ID.** Examples:
+   - Canvas course `12345` → `canvas-course-12345`
+   - Canvas assignment `987` → `canvas-assignment-987` (not `…-assignment-3`)
+   - Canvas file `555` → `canvas-file-555`
+3. **If the portal has no native ID**, use a **stable composite** of
+   attributes that do not change week to week (period + course title slug),
+   never an array index.
+4. **Never emit the grades-API merged course hash** (`12-char sha256` from
+   `course-reconciler`). That ID is a **read model**. Scrapers emit **raw**
+   platform IDs only. The API merges after ingest.
+5. **`key.courseExternalId` and `record.courseExternalId` must be identical**
+   when both are present.
+
+### Known gap (fix in transformers)
+
+The current Canvas transformer keys assignments as
+`canvas-{courseId}-assignment-{arrayIndex}`. Index-based IDs break join
+stability when the assignment list order changes. New scrapers MUST use
+native Canvas assignment IDs. Existing index IDs should be migrated, not
+copied.
+
+---
+
+## 4. Join-key contract (MUST)
+
+The course is the hub. Every academic fact points at a course that exists
+**in the same envelope**.
+
+```
+                    academicTerm
+                         ▲
+                         │ termExternalId
+                         │
+teacher ──courseExternalIds──► course ◄── courseExternalId ── assignment
+                                 ▲  ▲                            ▲
+                                 │  │                            │
+                    gradeSnapshot│  │courseMaterial              │
+                                 │  │   assignmentExternalId ────┘
+                                 │
+                          attendanceEvent / message
+```
+
+| Entity | Required join fields | Points at |
+|--------|----------------------|-----------|
+| `course` | `key.externalId` | (hub) |
+| `gradeSnapshot` | `key.courseExternalId` **and** `record.courseExternalId` | `course.key.externalId` |
+| `assignment` | `key.courseExternalId` **and** `record.courseExternalId` | `course.key.externalId` |
+| `courseMaterial` | `record.courseExternalId` | `course.key.externalId` |
+| `courseMaterial` | `record.assignmentExternalId` when the portal shows a link | `assignment.key.externalId` |
+| `attendanceEvent` | `record.courseExternalId` when period-level | `course.key.externalId` |
+| `message` | `record.courseExternalId` when course-scoped | `course.key.externalId` |
+| `teacher` | `record.courseExternalIds[]` | `course.key.externalId` |
+| `eventOverride` | `record.seriesExternalId` | `eventSeries.key.externalId` |
+| `academicTerm` | `record.parentTermExternalId` when nested | parent term `key.externalId` |
+
+**Envelope-local integrity:** every `courseExternalId` value MUST match a
+`course` op `key.externalId` in the same envelope (or the course must be
+emitted in that run). Dangling FKs are a scraper bug, not a server join
+problem.
+
+---
+
+## 5. Completeness by provider role
+
+Clients scrape whatever the portal shows. Roles tell the validator what
+"complete" means.
+
+### SIS — Skyward, Aeries (official record)
+
+| Entity | Floor | Why |
+|--------|-------|-----|
+| `course` | one per enrolled class | Hub for grades |
+| `gradeSnapshot` | one per course (current term) | Official percent / letter |
+| `academicTerm` | current grading period | Snapshot belongs to a term |
+| `assignment` | missing + graded in current term | SIS truth for "is it in the gradebook" |
+| `attendanceEvent` | if the portal has attendance | Alerts |
+| `studentProfile` | once per run | Identity |
+
+SIS scrapers **should** emit schedule fields on `course` (`period`,
+`teacherName`, `room`, `startTime` / `endTime`). Those are the strongest
+cross-provider join hints.
+
+### LMS — Canvas, Google Classroom (work and materials)
+
+| Entity | Floor | Why |
+|--------|-------|-----|
+| `course` | one per enrolled class | Hub for work |
+| `assignment` | every current-term assignment | Action board, missing work |
+| `courseMaterial` | files / modules / syllabus | Study resources |
+| `gradeSnapshot` | working grade if shown | Secondary; SIS wins on conflict |
+| `message` | course announcements | Context |
+
+LMS scrapers **should** emit `course.courseCode`, `course.period`,
+`course.teacherName`, assignment `dueAt` / `pointsPossible` / `category`,
+and material `fileName` + `extractedText`.
+
+### Google Classroom gap
+
+Classroom is **not** extracted on iOS today, and server-side Classroom fetch
+is discontinued. Until a client implements it, Classroom data will not
+appear. Web copy must say that. Do not store Google refresh tokens on the
+server as a workaround.
+
+---
+
+## 6. Join hints (SHOULD) — what intelligence actually uses
+
+Intelligence cannot join on vibes. It uses these fields. Omit them and
+match confidence drops.
+
+| Hint | Used by | If missing |
+|------|---------|------------|
+| `course.title` (raw portal text, do not over-clean) | Subject classifier + course merge | Cannot map Canvas ↔ Skyward |
+| `course.teacherName` | Split same-title courses (two Algebra 1s) | May merge the wrong sections |
+| `course.period` | Same | Same |
+| `course.courseCode` | Extra merge signal | Weaker SIS↔LMS match |
+| `assignment.title` | Assignment reconciler (title scorer) | Cannot suppress false "missing" |
+| `assignment.dueAt` | Date scorer | Title-only match |
+| `assignment.pointsPossible` | Points scorer | Title-only match |
+| `assignment.category` | Category scorer | Title-only match |
+| `courseMaterial.fileName` | Deterministic + LLM material match | Files stay unlinked |
+| `courseMaterial.extractedText` / description | LLM material match (layer 3) | Filename-only |
+| `courseMaterial.assignmentExternalId` | Direct join (best) | Fall back to layers 1–3 |
+| Canvas **modules** (`contentId` on Assignment + File items) | Layer 1 co-occurrence | Fall back to description links + LLM |
+| Assignment description HTML with file links | Layer 2 | Fall back to LLM |
+
+**Do not pre-merge courses on the client.** Emit Canvas courses with Canvas
+IDs and Skyward courses with Skyward IDs. The server's `course-reconciler`
+creates the merged subject. If the client merges first, SIS vs LMS
+precedence is lost.
+
+**Do not drop unmatched materials.** Upload them with `courseExternalId` and
+no `assignmentExternalId`. Layer 3 LLM matching runs on ingest for leftovers.
+
+---
+
+## 7. Intelligence layers (server)
+
+Joins run **after** a valid envelope is stored. Each layer is allowed to
+use only the fields in §6.
+
+```
+Layer 0  Intra-envelope FK
+         courseExternalId / assignmentExternalId as emitted
+         Deterministic. Failure = scraper bug.
+
+Layer 1  Subject classification
+         packages/connector/.../subject-reconciler.ts
+         Title → { area, subArea, honors/AP, period, teacher token }
+         Keyword taxonomy, confidence high/medium/low.
+
+Layer 2  Cross-provider course merge
+         packages/connector/.../course-reconciler.ts
+         Group by normalizedTitle|area|subArea
+         Split when BOTH period AND teacher differ
+         mergedId = 12-char hash (grades API only)
+
+Layer 3  Material → assignment (same course, same provider)
+         L1: Canvas module co-occurrence (client transformer)
+         L2: file URL/name in assignment description (client transformer)
+         L3: LLM filename ↔ assignment title (ingest, fire-and-forget)
+         Writes record.assignmentExternalId
+
+Layer 4  Cross-provider assignment match
+         packages/connector/.../assignment-reconciler.ts
+         LMS assignment ↔ SIS assignment inside the same merged course
+         Signals: title, points, due date, category, sequence
+         Used to suppress "missing" when SIS already graded it
+
+Layer 5  Grade precedence
+         SIS (Skyward/Aeries) > LMS (Canvas/Classroom)
+         See docs/grade-precedence.md
+```
+
+### How to join subjects, resources, and grades
+
+**Same provider (one envelope):** Layer 0. If `gradeSnapshot.courseExternalId`
+equals `course.key.externalId` and `courseMaterial.courseExternalId` equals
+the same, they are already the same subject. Prefer also setting
+`courseMaterial.assignmentExternalId`.
+
+**Two providers (Canvas + Skyward for one student):**
+
+1. Layer 1 classifies both course titles (`algebra🔢` and `ALGEBRA 1` →
+   math/algebra).
+2. Layer 2 merges them if period/teacher do not conflict.
+3. Grades API returns the **merged** course id and the SIS percent as
+   `officialGrade`.
+4. Action-board assignments keep **raw** LMS `assignmentExternalId`.
+5. Materials stay on the LMS course id; the grades UI aggregates material
+   counts across all source ids in the merged group.
+
+**Never join grades ↔ action-board on `courseExternalId`.** Grades responses
+use merged hashes; assignment rows use raw platform ids. The only id that
+is raw in **both** APIs is `assignmentExternalId`.
+
+---
+
+## 8. Validator gates
+
+`validateEnvelope()` in `@scholaracle/scraper-core` is the gate every client
+runs before upload.
+
+| Check | Severity | Meaning |
+|-------|----------|---------|
+| Schema / run / source / per-op required fields | **error** | Envelope rejected |
+| Course-scoped entity missing `courseExternalId` | **warning** | Ungradeable / unlinkable row |
+| `courseExternalId` not present as a `course` op | **warning** | Dangling FK |
+| `assignmentExternalId` on a material not present as an assignment op | **warning** | Dangling FK |
+| Course missing all of `teacherName`, `period`, `courseCode` | **warning** | Weak cross-provider merge |
+| SIS run with courses but no `gradeSnapshot` | **warning** | No official grades |
+| LMS run with courses but no `assignment` | **warning** | No work to show |
+| LMS run with courses but no `courseMaterial` | **warning** | No resources to join |
+
+Warnings do not fail the run (`passed` is still true if `errorCount === 0`).
+They are how we know a scraper is incomplete. Treat new warnings as bugs.
+
+---
+
+## 9. Transform vs scrape
+
+| Layer | Responsibility |
+|-------|----------------|
+| **Recipe / extract** | Visit every required page; capture native ids, titles, files, modules |
+| **Transformer** | Map to `ISlcDeltaOp[]`; set join keys; run Layer 1–2 material match when portal structure exists |
+| **Validator** | Reject malformed envelopes; warn on unjoinable graphs |
+| **Upload** | `POST /api/ingest/v1/runs/:runId/envelope` only — never credentials |
+| **Server ingest** | Persist ops; Layer 3 LLM materials; alerts; later Layers 2/4/5 on read |
+
+Transformers are pure. They must not call `Date.now()` for identity, must
+not log secrets, and must not invent grades. Report the portal's number.
+
+---
+
+## 10. Minimum viable envelope (example)
+
+```json
+{
+  "schemaVersion": "slc.ingest.v1",
+  "run": {
+    "runId": "…",
+    "startedAt": "2026-08-14T12:00:00Z",
+    "provider": "canvas",
+    "adapterId": "canvas::default",
+    "adapterVersion": "canvas@1.0.0+core@0.1.0",
+    "mode": "delta",
+    "timezone": "America/Chicago",
+    "meta": { "clientType": "mobile" }
+  },
+  "source": { "sourceId": "src-canvas", "displayName": "District Canvas" },
+  "ops": [
+    {
+      "op": "upsert",
+      "entity": "course",
+      "key": { "provider": "canvas", "adapterId": "canvas::default", "externalId": "canvas-course-123" },
+      "observedAt": "2026-08-14T12:00:00Z",
+      "record": { "title": "Algebra 1", "period": "4", "teacherName": "Chang", "courseCode": "ALG1" }
+    },
+    {
+      "op": "upsert",
+      "entity": "assignment",
+      "key": {
+        "provider": "canvas",
+        "adapterId": "canvas::default",
+        "externalId": "canvas-assignment-987",
+        "courseExternalId": "canvas-course-123"
+      },
+      "observedAt": "2026-08-14T12:00:00Z",
+      "record": {
+        "title": "5.A - Independent Practice",
+        "courseExternalId": "canvas-course-123",
+        "dueAt": "2026-08-15T05:00:00Z",
+        "pointsPossible": 10,
+        "status": "missing"
+      }
+    },
+    {
+      "op": "upsert",
+      "entity": "courseMaterial",
+      "key": {
+        "provider": "canvas",
+        "adapterId": "canvas::default",
+        "externalId": "canvas-file-555",
+        "courseExternalId": "canvas-course-123"
+      },
+      "observedAt": "2026-08-14T12:00:00Z",
+      "record": {
+        "title": "5.A Independent Practice.pdf",
+        "courseExternalId": "canvas-course-123",
+        "assignmentExternalId": "canvas-assignment-987",
+        "type": "document",
+        "fileName": "5.A Independent Practice.pdf"
+      }
+    }
+  ]
+}
+```
+
+That envelope is fully joinable **inside Canvas**. A Skyward envelope for
+the same student with `title: "ALGEBRA 1"`, `period: "4"`, `teacherName:
+"Noah Chang"` lets Layers 1–2 merge the subject and Layer 5 pick the
+Skyward snapshot as the official grade.
+
+---
+
+## 11. Out of scope for clients
+
+- Merging Canvas + Skyward courses into one id
+- Computing GPA or category weights the portal does not show
+- Uploading portal username / password
+- Launching Chromium on Scholaracle servers
+- Implementing Google Classroom on iOS in this spec (document the gap only)

--- a/docs/DATA_EXTRACTION_CHECKLIST.md
+++ b/docs/DATA_EXTRACTION_CHECKLIST.md
@@ -3,8 +3,13 @@
 > Version 1.0 — 2026-02-16
 >
 > This checklist defines **everything** a scraper should extract from an educational platform.
-> It is embedded into AI prompts for scraper generation and serves as the authoritative
-> reference for what data the Scholaracle system can ingest.
+> It is embedded into AI prompts for scraper generation and serves as the field catalog
+> for what the Scholaracle system can ingest.
+>
+> **Join keys, provider roles, and intelligence layers** live in
+> [`CLIENT_SCRAPER_SPEC.md`](./CLIENT_SCRAPER_SPEC.md). Extract the fields below
+> **and** emit the join keys in that spec, or subjects / grades / resources
+> cannot be stitched together.
 >
 > **Rule: If the platform shows it on any page, scrape it. Navigate to every page necessary.
 > If a data point is not available on the platform, omit the field — but always check.**
@@ -56,6 +61,10 @@ Extract once per scraper run. This tells the system who the child is.
 
 Extract one record per course the student is enrolled in.
 
+`key.externalId` is the hub other entities point at. Prefer a native platform
+id (`canvas-course-12345`). Always emit `title` plus at least one join hint:
+`teacherName`, `period`, or `courseCode`.
+
 | Field | Type | Notes |
 |-------|------|-------|
 | **title** [required] | string | Course name: "AP Mathematics", "English 10 Honors" |
@@ -79,6 +88,9 @@ Extract one record per course the student is enrolled in.
 ### 3. Assignments (`assignment`)
 
 Extract **every assignment** for the current term at minimum. Historical terms are valuable too.
+
+`key.courseExternalId` and `record.courseExternalId` MUST equal the parent
+course's `key.externalId`. Prefer a native assignment id, never an array index.
 
 | Field | Type | Notes |
 |-------|------|-------|
@@ -131,6 +143,9 @@ Extract **every assignment** for the current term at minimum. Historical terms a
 ### 4. Grade Snapshots (`gradeSnapshot`)
 
 Extract one per course per grading period. This is the "report card" view.
+
+`record.courseExternalId` MUST equal the parent course's `key.externalId`.
+SIS snapshots are the official grade; LMS snapshots are working grades.
 
 | Field | Type | Notes |
 |-------|------|-------|
@@ -205,6 +220,10 @@ Extract one record per teacher the student has.
 ### 7. Course Materials (`courseMaterial`)
 
 Extract all documents, files, and resources posted to courses.
+
+`record.courseExternalId` is required. Set `record.assignmentExternalId` when
+the portal groups the file with an assignment (module, description link,
+attachment). Unmatched files still upload — server LLM matching fills the gap.
 
 | Field | Type | Notes |
 |-------|------|-------|

--- a/docs/DEPLOY_SYNC_VERIFY.md
+++ b/docs/DEPLOY_SYNC_VERIFY.md
@@ -1,12 +1,14 @@
-# Deploy and Verify Sync Pipeline
+# Deploy and Verify Notification Pipeline
 
-After implementing the Fix Sync Pipeline plan, use this checklist to deploy and verify end-to-end.
+After deploying, use this checklist to confirm the notification pipeline works end-to-end.
+School-portal scraping now runs **client-side only** (iOS app, browser extension, or local CLI).
+Workers receive ingest envelopes and send alerts — they do not scrape.
 
 ## 1. Deploy to Railway
 
-Deploy the monorepo (or `api` and `workers` services) to your Railway project.
+Deploy the monorepo (`api` and `workers` services) to your Railway project.
 
-- Ensure `api` and `workers` both build and deploy (connector, agents, workers, api).
+- Ensure `api` and `workers` both build and deploy.
 - Workers need `@scholaracle/auth` and env for ingest submission.
 
 ## 2. Environment variables
@@ -15,47 +17,61 @@ Set on **both** `api` and `workers` where applicable:
 
 | Variable | Where | Notes |
 |----------|--------|--------|
-| `CREDENTIALS_ENCRYPTION_KEY` | api, workers | **Must be identical** so workers can decrypt credentials. |
 | `JWT_SECRET` | api, workers | Same secret so workers can create connector tokens for ingest. |
-| `API_BASE_URL` | workers | Base URL of the API (e.g. `https://your-api.railway.app`) for creating ingest runs and submitting envelopes. |
-| `GOOGLE_CLASSROOM_CLIENT_ID` | api | For OAuth authorize/callback. |
-| `GOOGLE_CLASSROOM_CLIENT_SECRET` | api | For OAuth token exchange. |
-| `GOOGLE_CLASSROOM_CLIENT_ID` / `GOOGLE_CLASSROOM_CLIENT_SECRET` | workers | For Google token refresh before sync. |
+| `API_BASE_URL` | workers | Base URL of the API for submitting envelopes. |
+| `SENDGRID_API_KEY` | api, workers | Notification emails. |
+| `TWILIO_ACCOUNT_SID` / `TWILIO_AUTH_TOKEN` / `TWILIO_FROM_NUMBER` | workers | SMS alerts. |
+| `FIREBASE_PROJECT_ID` | workers | Push notifications. |
+| `CREDENTIALS_ENCRYPTION_KEY` | api, workers | For encrypting non-portal secrets (API tokens). |
 
-## 3. Trigger Skyward sync for Ava
+Note: `GOOGLE_CLASSROOM_CLIENT_ID` / `GOOGLE_CLASSROOM_CLIENT_SECRET` are no longer needed.
+Server-side Google Classroom sync has been discontinued. The `/api/oauth/google` endpoints return 410 Gone.
 
-- Student ID: `69a4f1b53671c632ca591c7f`
-- Skyward source ID: `7da26591-242d-401b-95c6-54eb2a1f7d1a`
-- Credentials (Jessica.Lewis / 123456789, Lake Dallas Skyward URL) should already be set.
+## 3. Submit a test ingest envelope
 
-Trigger sync via dashboard (student → source → Sync) or:
+Use the mobile app, browser extension, or local CLI to run a sync and submit an envelope:
 
 ```bash
-# If you have API access (replace BASE_URL and auth token)
-curl -X POST "https://<BASE_URL>/api/sync/students/69a4f1b53671c632ca591c7f/<dsIndex>" \
-  -H "Authorization: Bearer <JWT>"
+# CLI example
+slc run --source-id <id> --student-id <id>
 ```
 
-Use the data source index for Ava’s Skyward source (e.g. 0 if it’s the first source).
+Or submit a synthetic envelope directly:
+
+```bash
+curl -X POST "https://<API_BASE>/api/ingest/v1/runs/<runId>/envelope" \
+  -H "Authorization: Bearer <connector-token>" \
+  -H "Content-Type: application/json" \
+  -d '{ "schemaVersion": "slc.ingest.v1", ... }'
+```
 
 ## 4. Verify
 
-1. **Sync run**  
-   Check `sync_runs` (or dashboard) for a completed run for Ava’s Skyward source.
+1. **Ingest run**
+   Confirm an ingest run was created and envelope committed (check `slc_runs` collection or ingest APIs).
 
-2. **Ingest**  
-   Confirm an ingest run was created and envelope submitted (e.g. `slc_runs` or ingest APIs).
+2. **Alerts**
+   Confirm alerts were generated from ingested data (missing assignments, grade changes).
 
-3. **Alerts**  
-   Confirm alerts were generated from ingested data (e.g. missing assignments, grades).
+3. **Digest**
+   Confirm digest email is sent to recipients.
 
-4. **Digest**  
-   Confirm `email_digest_pending` (or equivalent) is populated and digest is sent to 3 recipients.
+## 5. Verify server rejects portal sync (guardrails)
 
-## 5. Optional: Google Classroom
+Confirm the server correctly refuses legacy server-scraping paths:
 
-To test Google Classroom:
+```bash
+# Should return 400 — server no longer scrapes Canvas
+curl -X POST "https://<API_BASE>/api/sync/students/<id>/0" \
+  -H "Authorization: Bearer <JWT>"
 
-1. Set `GOOGLE_CLASSROOM_CLIENT_ID` and `GOOGLE_CLASSROOM_CLIENT_SECRET` on the API (and workers for refresh).
-2. In Connect Source Wizard, choose Google Classroom and click “Authorize with Google”.
-3. Complete OAuth and run a sync; verify envelope and digest as above.
+# Should return 400 — server no longer accepts login credentials
+curl -X PUT "https://<API_BASE>/api/students/<id>/sources/<sid>/credentials" \
+  -H "Authorization: Bearer <JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{ "authType": "login", "username": "x", "password": "y" }'
+
+# Should return 410 — Google Classroom server OAuth is discontinued
+curl "https://<API_BASE>/api/oauth/google/authorize" \
+  -H "Authorization: Bearer <JWT>"
+```

--- a/docs/SOURCE_INVITE.md
+++ b/docs/SOURCE_INVITE.md
@@ -1,0 +1,78 @@
+# Source Invite — Engineering Specification
+
+**Status:** v1 — implementation source of truth  
+**Tests cite:** `SOURCE_INVITE.md §N`
+
+A **source invite** is not a scraper package. One opaque HTTPS link registers a builtin portal (Canvas / Skyward / Aeries + school URL) on the client. Portal passwords never appear in email, URLs, or issue JSON.
+
+## §1 Product
+
+One email, one token, two last-mile buttons:
+
+1. Landing `GET {apiOrigin}/install-source?t={token}` (public HTML, no login).
+2. **Open in Scholarmancy** → `scholarmancy://install-source?t={token}` (Expo iOS and Android).
+3. **Continue in browser** → `{webOrigin}/dashboard/install-source?t={token}`.
+4. Authenticated **redeem** returns metadata only. The user types the portal password on-device (app WebView or extension).
+
+Ava fixture: provider `skyward`, portal `https://skyward.iscorp.com`.
+
+Do not email binaries, `.command`, or JS. Google Classroom OAuth is a later `authMethod` on this envelope.
+
+## §2 Identity
+
+| Field | Meaning |
+|---|---|
+| Issue `studentId` | Scholaracle Mongo id (`IStudentListItem.id`) |
+| Payload `studentExternalId` | SIS id (`IStudentListItem.studentId`) or Mongo id if missing |
+| `institutionExternalId` | Portal hostname |
+| Local `sourceId` | `local-{provider}-{hostname}` |
+| Mobile `adapterId` | `com.instructure.canvas` / `com.skyward.iscorp` / `com.aeries.portal` |
+
+Unknown or other-user student → `404 NOT_FOUND`. Never persist `'default'` as `studentExternalId`.
+
+## §3 Contracts
+
+Types in `@scholaracle/contracts` (`ISourceInvitePayload`, issue/redeem request/response). Payload JSON keys are exactly:
+
+`provider`, `adapterId`, `portalBaseUrl`, `displayName`, `studentId`, `studentExternalId`, `institutionExternalId`.
+
+Issue HTTP response keys are exactly: `success`, `expiresAt`, `emailedTo`. **Forbidden:** `token`, `landingUrl`, `portalBaseUrl`, `studentExternalId`.
+
+`assertNoSecrets` rejects secret-like keys except redeem top-level `token`, stored `tokenHash`, and mailer `landingUrl`.
+
+## §4 ISP
+
+Callers depend on small interfaces: `IClock`, `ITokenGenerator`, `ITokenHasher`, `ISourceInviteStore`, `IStudentOwnerLookup`, `ISourceInviteIssuer`, `ISourceInviteRedeemer`, `ISourceInviteMailer`, `IInstallLandingRenderer`, `IInstallSourceLinkParser`, `ISourceInviteApplier`, `IPendingSourceInviteStore`.
+
+Issuer returns `{ token, expiresAt, payload }` internally. The HTTP route strips the token, emails the landing URL, and returns `ISourceInviteIssueResponse`.
+
+Store collection `source_invites`: hash only, never the raw token. TTL index on `expiresAt`. Unique `tokenHash`.
+
+## §5 Validation
+
+- Portal URL: `https` only, no userinfo, nonempty host, strip trailing slashes, lowercase host.
+- Token: 32 random bytes → 64 hex. Echo only `/^[a-f0-9]{64}$/i`.
+- TTL 7 days. One-shot consume. Re-issue invalidates prior open invites for the same `(userId, studentId, provider, institutionExternalId)`.
+- Redeem failures (expired, consumed, wrong user, missing) share the message: `This install link expired or is not for this account.` Wire as `404 NOT_FOUND`.
+
+## §6 HTTP
+
+| Method | Path | Auth |
+|---|---|---|
+| POST | `/api/source-invites` | JWT |
+| POST | `/api/source-invites/redeem` | JWT |
+| GET | `/install-source` | none |
+
+Issue: self-email only (`to` in body → 400). Rate limit 5/hour per user. Landing is **stateless** (no Mongo). Sanitize `t`. Open + Continue buttons. Invalid `t` still HTTP 200 (no oracle). HTML must not contain portal hosts, passwords, or student names.
+
+## §7 Email
+
+Subject: `Install {providerName} in Scholarmancy`. Branded HTML. One HTTPS landing URL. Copy: this message never includes your school password. Empty SendGrid key no-ops.
+
+## §8 Mobile
+
+Parse `scholarmancy://install-source?t=` with string operations (never `URL`). Logged out: save token in `IPendingSourceInviteStore`. Logged in: redeem → apply (no SecureStore) → `ConnectSourceScreen` credentials step with URL locked.
+
+## §9 Web continue
+
+`/dashboard/install-source?t=`. Login redirect preserves `t`. Redeem, then `replaceState` to drop `t`. Prefill via sessionStorage (not a query with `portalBaseUrl`). No server-side password form. Dashboard **Email me an install link** posts only the allowlisted issue body.

--- a/docs/connector-spec.md
+++ b/docs/connector-spec.md
@@ -604,43 +604,41 @@ Parent → School Platform → Adapter → SLC Envelope → Scholaracle API → 
 
 | Platform Tier | Connection Method | Runs On | Parent Effort |
 |---------------|-------------------|---------|---------------|
-| Tier 1 (API) | OAuth or token via web UI | Server (workers) | Low: enter URL + auth |
-| Tier 2 (OneRoster) | District credentials via web UI | Server (workers) | Low: enter URL + auth |
-| Tier 3 (Partner) | API token via web UI (if granted) | Server (workers) | Low |
-| Tier 4 (Scrape) | Install local connector + Playwright | Parent's machine | Medium: install + run |
+| Tier 1 (API) | OAuth or API token — client-side only | Mobile app / extension / CLI | Low: authenticate in app |
+| Tier 2 (OneRoster) | District API token — client-side only | Mobile app / extension / CLI | Low: enter token in app |
+| Tier 3 (Partner) | API token — client-side only | Mobile app / extension / CLI | Low: enter token in app |
+| Tier 4 (Scrape) | Local Playwright-based connector | Parent's machine (CLI) | Medium: install + run |
 
-### 5.3 Server-Side Sync (Tiers 1–3)
+**All sync runs client-side.** School portal credentials and OAuth tokens are held on the
+client device (iOS Keychain, browser extension local storage, or CLI config file) and are
+never uploaded to the Scholaracle server. The server only receives normalized SLC envelopes.
 
-For platforms with APIs, syncing runs server-side:
+### 5.3 Client-Side Sync Flow
 
-1. Parent enters school URL in web UI
-2. Platform detector identifies the platform
-3. Parent completes auth flow (OAuth redirect, paste token, or enter credentials)
-4. Credentials encrypted and stored in `IngestCredential` collection
-5. Worker job `ingest-sync` runs on schedule (every 4–6 hours):
-   - Reads IngestSource records
-   - Instantiates adapter from registry
-   - Calls `fetchEnvelope()`
-   - Applies ops to database
-   - Updates IngestRun status
+For all platforms, extraction runs on the client:
 
-### 5.4 Local Connector (Tier 4)
+1. Parent authenticates in the iOS app, browser extension, or local CLI
+2. Credentials stored locally (Keychain / extension storage / `~/.scholaracle/`)
+3. Client runs adapter on schedule or on demand
+4. Client calls `fetchEnvelope()` and POSTs the SLC envelope to the ingest API
+5. Server validates, stores, and generates alerts — no scraping on the server
 
-For scraping, the connector runs on the parent's machine:
+### 5.4 Local CLI Connector (Tier 4 Scrape)
+
+For portal scraping, the connector runs on the parent's machine:
 
 1. Parent installs Node.js + `@scholaracle/connector` CLI
 2. `slc init` — device auth flow (get connector token)
 3. `slc add-source` — register the school portal
-4. `slc run --source-id <id> --scrape` — launches Playwright, logs in, scrapes data
+4. `slc run --source-id <id> --scrape` — launches Playwright locally, logs in, scrapes data
 5. Envelope uploaded to Scholaracle API
 
 ### 5.5 Credential Security
 
-- All credentials encrypted at rest using AES-256-GCM
-- OAuth tokens refreshed automatically; refresh tokens stored encrypted
-- API keys and passwords never logged or exposed in responses
-- Local connector stores `connectorToken` in `~/.scholaracle/slc.json`
-- Server-side credentials stored in separate `IngestCredential` collection
+- School portal credentials (username/password, OAuth tokens) are **never** sent to or stored by the Scholaracle server
+- Client devices store credentials locally using OS-level secure storage (iOS Keychain, extension storage, file system)
+- The server stores only normalized academic data and non-portal API tokens (e.g. integration API keys)
+- Connector tokens used by CLI clients are scoped to a single student source
 
 ---
 

--- a/docs/scrape-harness-spec.md
+++ b/docs/scrape-harness-spec.md
@@ -8,6 +8,9 @@ The scrape test harness validates that **real data** from education platforms
 is scraped/fetched correctly and conforms to the application's ingest contract.
 It uses the **same adapter code** as production — no mocks, no stubs.
 
+Client scraper join keys and completeness gates:
+[`CLIENT_SCRAPER_SPEC.md`](./CLIENT_SCRAPER_SPEC.md).
+
 ## 2. Architecture
 
 ```

--- a/packages/agents/src/scheduler/SyncScheduler/SyncScheduler.ts
+++ b/packages/agents/src/scheduler/SyncScheduler/SyncScheduler.ts
@@ -99,6 +99,13 @@ export class SyncScheduler {
     userId: string;
     triggeredByUserId?: string;
   }): Promise<string> {
+    if (
+      ['canvas', 'skyward', 'aeries', 'google-classroom', 'oneroster'].includes(params.provider)
+    ) {
+      throw new Error(
+        `${params.provider} sync is client-side only. Do not enqueue server-side jobs for this provider.`
+      );
+    }
     const jobData: ISyncJobData = {
       studentId: params.studentId,
       dataSourceIndex: params.dataSourceIndex,
@@ -178,6 +185,11 @@ export class SyncScheduler {
     for (const src of sources) {
       const schedule = (src['schedule'] as string) ?? 'daily';
       if (schedule === 'manual') continue;
+
+      // HTML-portal providers are synced client-side only; skip server-side scheduling.
+      const srcProvider = (src['provider'] as string | undefined) ?? '';
+      if (['canvas', 'skyward', 'aeries', 'google-classroom', 'oneroster'].includes(srcProvider))
+        continue;
 
       // Skip day-of-week restricted schedules when not applicable
       if (schedule === 'weekdays' && !isWeekday(now)) continue;

--- a/packages/agents/src/worker/SyncWorker/SyncWorker.ts
+++ b/packages/agents/src/worker/SyncWorker/SyncWorker.ts
@@ -69,7 +69,7 @@ export interface ISyncRun {
 
 // ---------------------------------------------------------------------------
 // Adapter runner — this is the function the SyncWorker calls.
-// It is injected so the agents package doesn't depend on connector/playwright.
+// Injected to keep the agents package decoupled from connector implementations.
 // ---------------------------------------------------------------------------
 
 export interface IAdapterRunnerOptions {
@@ -193,6 +193,16 @@ export class SyncWorker {
     const { insertedId } = await this._runs.insertOne(run);
 
     try {
+      // Reject all client-side providers before touching credentials.
+      // Canvas, Skyward, Aeries, Google Classroom, and OneRoster are all synced client-side.
+      if (
+        ['canvas', 'skyward', 'aeries', 'google-classroom', 'oneroster'].includes(data.provider)
+      ) {
+        throw new Error(
+          `${data.provider} sync is client-side only (mobile app, browser extension, or local CLI). The server must not process sync jobs for this provider.`
+        );
+      }
+
       // 1. Resolve credentials from the student document
       const students = this._db.collection('students');
       const student = await students.findOne({

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,6 +29,7 @@
     "@scholaracle/database": "workspace:^",
     "@scholaracle/interfaces": "workspace:*",
     "@scholaracle/logger": "workspace:*",
+    "@scholaracle/scraper-core": "workspace:*",
     "@sendgrid/mail": "^8.1.0",
     "@sentry/node": "^10.0.0",
     "@types/archiver": "^7.0.0",

--- a/packages/api/src/routes/agenda/agenda.test.ts
+++ b/packages/api/src/routes/agenda/agenda.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import express, { type Express } from 'express';
 import { MongoClient, type Db } from 'mongodb';
 import { AuthService } from '@scholaracle/auth';
+import { StudentRepository } from '@scholaracle/database';
 import { agendaRouter } from './agenda';
 import { createErrorHandler } from '../../middleware/errorHandler';
 
@@ -21,14 +22,26 @@ describe('Agenda API', () => {
     database = mongoClient.db(dbName);
 
     await database.collection('users').deleteMany({ email: 'agenda@test.com' });
+    await database.collection('students').deleteMany({ studentId: 'student-ext-1' });
     await database.collection('slc_assignments').deleteMany({});
     await database.collection('slc_event_series').deleteMany({});
     await database.collection('agenda_overrides').deleteMany({});
 
     authService = new AuthService(database);
     const reg = await authService.register('agenda@test.com', 'password123', 'Agenda User');
-    if (!reg.success || !reg.token) throw new Error('Failed to create agenda test user');
+    if (!reg.success || !reg.token || !reg.user?.id) {
+      throw new Error('Failed to create agenda test user');
+    }
     testToken = reg.token;
+
+    // Agenda queries slc_* by student.dataUserId(); assignments without a student never surface.
+    const studentRepo = new StudentRepository(database);
+    await studentRepo.create({
+      userId: reg.user.id,
+      name: 'Agenda Student',
+      grade: 9,
+      studentId: 'student-ext-1',
+    });
 
     app = express();
     app.use(express.json());

--- a/packages/api/src/routes/ingest/v1/enrichOps.test.ts
+++ b/packages/api/src/routes/ingest/v1/enrichOps.test.ts
@@ -1,0 +1,132 @@
+/**
+ * prepareIngestOps — TDD for off / shadow / apply (fail-open).
+ */
+
+import type { ISlcDeltaOp } from '@scholaracle/contracts';
+import type { IAIEnricher } from '@scholaracle/scraper-core';
+import { parseEnrichOpsMode, prepareIngestOps, resolveEnrichOpsMode } from './enrichOps';
+
+const NOW = '2026-01-15T10:00:00.000Z';
+
+function op(
+  entity: ISlcDeltaOp['entity'],
+  externalId: string,
+  record: Record<string, unknown>
+): ISlcDeltaOp {
+  return {
+    op: 'upsert',
+    entity,
+    key: {
+      provider: 'skyward',
+      adapterId: 'com.skyward.grade',
+      studentExternalId: 'stu-1',
+      institutionExternalId: 'inst-1',
+      externalId,
+    },
+    observedAt: NOW,
+    record,
+  };
+}
+
+const course = op('course', 'skyward-course-A1', {
+  title: 'ALGEBRA 1',
+  period: '1',
+  teacherName: 'Smith',
+});
+const attendanceGap = op('attendanceEvent', 'att-1', {
+  date: '2026-01-10',
+  status: 'present',
+  periodName: '1',
+});
+const gappedOps = [course, attendanceGap];
+
+describe('parseEnrichOpsMode', () => {
+  it('defaults unknown and empty values to off', () => {
+    expect(parseEnrichOpsMode(undefined)).toBe('off');
+    expect(parseEnrichOpsMode('')).toBe('off');
+    expect(parseEnrichOpsMode('APPLY')).toBe('off');
+  });
+
+  it('accepts off, shadow, and apply', () => {
+    expect(parseEnrichOpsMode('off')).toBe('off');
+    expect(parseEnrichOpsMode('shadow')).toBe('shadow');
+    expect(parseEnrichOpsMode('apply')).toBe('apply');
+  });
+});
+
+describe('resolveEnrichOpsMode', () => {
+  const previous = process.env['ENRICH_OPS_MODE'];
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env['ENRICH_OPS_MODE'];
+    else process.env['ENRICH_OPS_MODE'] = previous;
+  });
+
+  it('prefers explicit config over the environment', () => {
+    process.env['ENRICH_OPS_MODE'] = 'apply';
+    expect(resolveEnrichOpsMode('shadow')).toBe('shadow');
+  });
+
+  it('reads ENRICH_OPS_MODE when config is omitted', () => {
+    process.env['ENRICH_OPS_MODE'] = 'apply';
+    expect(resolveEnrichOpsMode()).toBe('apply');
+  });
+});
+
+describe('prepareIngestOps', () => {
+  it('off returns original ops and does not patch', async () => {
+    const result = await prepareIngestOps({ ops: gappedOps, mode: 'off' });
+    expect(result.ops).toBe(gappedOps);
+    expect(result.patchCount).toBe(0);
+    expect(result.applied).toBe(false);
+    expect(result.ops[1]?.record?.['courseExternalId']).toBeUndefined();
+  });
+
+  it('shadow reports patches but returns original ops', async () => {
+    const result = await prepareIngestOps({ ops: gappedOps, mode: 'shadow' });
+    expect(result.patchCount).toBeGreaterThan(0);
+    expect(result.applied).toBe(false);
+    expect(result.ops).toBe(gappedOps);
+    expect(result.ops[1]?.record?.['courseExternalId']).toBeUndefined();
+  });
+
+  it('apply fills attendance courseExternalId from a unique period', async () => {
+    const result = await prepareIngestOps({ ops: gappedOps, mode: 'apply' });
+    expect(result.applied).toBe(true);
+    expect(result.failed).toBe(false);
+    expect(result.ops[1]?.record?.['courseExternalId']).toBe('skyward-course-A1');
+    expect(result.ops[1]?.key.courseExternalId).toBe('skyward-course-A1');
+  });
+
+  it('apply is idempotent when the FK is already filled', async () => {
+    const filled = await prepareIngestOps({ ops: gappedOps, mode: 'apply' });
+    const again = await prepareIngestOps({ ops: filled.ops, mode: 'apply' });
+    expect(again.patchCount).toBe(0);
+    expect(again.applied).toBe(false);
+    expect(again.ops[1]?.record?.['courseExternalId']).toBe('skyward-course-A1');
+  });
+
+  it('apply falls back to original ops when revalidate fails', async () => {
+    const result = await prepareIngestOps({
+      ops: gappedOps,
+      mode: 'apply',
+      revalidate: () => ({ valid: false, error: 'nope' }),
+    });
+    expect(result.applied).toBe(false);
+    expect(result.failed).toBe(true);
+    expect(result.ops).toBe(gappedOps);
+    expect(result.patchCount).toBeGreaterThan(0);
+  });
+
+  it('apply falls back to original ops when the enricher throws', async () => {
+    const boom: IAIEnricher = {
+      async enrich() {
+        throw new Error('model down');
+      },
+    };
+    const result = await prepareIngestOps({ ops: gappedOps, mode: 'apply', enricher: boom });
+    expect(result.ops).toBe(gappedOps);
+    expect(result.applied).toBe(false);
+    expect(result.failed).toBe(true);
+  });
+});

--- a/packages/api/src/routes/ingest/v1/enrichOps.ts
+++ b/packages/api/src/routes/ingest/v1/enrichOps.ts
@@ -1,0 +1,119 @@
+/**
+ * Server-side join-gap enrichment for ingest envelopes.
+ *
+ * Same JoinGapEnricher + sanitizer as client `runClientScrape`. Fail-open:
+ * throws, illegal patches, and revalidation failures fall back to original ops.
+ *
+ * Modes (ENRICH_OPS_MODE or IIngestV1RouterConfig.enrichOpsMode):
+ *   off    — identity (default; production-safe)
+ *   shadow — enrich and record patchCount, apply original ops
+ *   apply  — enrich, revalidate, apply enriched ops (or original on failure)
+ */
+
+import type { ISlcDeltaOp } from '@scholaracle/contracts';
+import {
+  JoinGapEnricher,
+  applyEnrichersFailOpen,
+  type IAIEnricher,
+} from '@scholaracle/scraper-core';
+
+export type EnrichOpsMode = 'off' | 'shadow' | 'apply';
+
+export interface IPrepareIngestOpsResult {
+  readonly ops: readonly ISlcDeltaOp[];
+  readonly mode: EnrichOpsMode;
+  readonly patchCount: number;
+  readonly failed: boolean;
+  readonly applied: boolean;
+}
+
+export interface IPrepareIngestOpsParams {
+  readonly ops: readonly ISlcDeltaOp[];
+  readonly mode: EnrichOpsMode;
+  /** Override for tests. Production uses JoinGapEnricher. */
+  readonly enricher?: IAIEnricher;
+  readonly revalidate?: (ops: readonly ISlcDeltaOp[]) => { valid: boolean; error?: string };
+}
+
+const defaultJoinGap = new JoinGapEnricher();
+
+export function parseEnrichOpsMode(raw: string | undefined): EnrichOpsMode {
+  if (raw === 'shadow' || raw === 'apply' || raw === 'off') return raw;
+  return 'off';
+}
+
+export function resolveEnrichOpsMode(configMode?: EnrichOpsMode): EnrichOpsMode {
+  if (configMode) return configMode;
+  return parseEnrichOpsMode(process.env['ENRICH_OPS_MODE']);
+}
+
+export async function prepareIngestOps(
+  params: IPrepareIngestOpsParams
+): Promise<IPrepareIngestOpsResult> {
+  const { mode } = params;
+  if (mode === 'off') {
+    return {
+      ops: params.ops,
+      mode,
+      patchCount: 0,
+      failed: false,
+      applied: false,
+    };
+  }
+
+  const original = params.ops as ISlcDeltaOp[];
+  const enrichment = await applyEnrichersFailOpen({
+    enrichers: [params.enricher ?? defaultJoinGap],
+    rawExtract: {},
+    ops: original,
+  });
+
+  if (mode === 'shadow') {
+    return {
+      ops: params.ops,
+      mode,
+      patchCount: enrichment.patchCount,
+      failed: enrichment.failed,
+      applied: false,
+    };
+  }
+
+  if (enrichment.failed) {
+    return {
+      ops: params.ops,
+      mode,
+      patchCount: enrichment.patchCount,
+      failed: true,
+      applied: false,
+    };
+  }
+
+  if (enrichment.patchCount === 0) {
+    return {
+      ops: enrichment.ops,
+      mode,
+      patchCount: 0,
+      failed: false,
+      applied: false,
+    };
+  }
+
+  const check = params.revalidate?.(enrichment.ops) ?? { valid: true };
+  if (!check.valid) {
+    return {
+      ops: params.ops,
+      mode,
+      patchCount: enrichment.patchCount,
+      failed: true,
+      applied: false,
+    };
+  }
+
+  return {
+    ops: enrichment.ops,
+    mode,
+    patchCount: enrichment.patchCount,
+    failed: false,
+    applied: true,
+  };
+}

--- a/packages/api/src/routes/ingest/v1/index.ts
+++ b/packages/api/src/routes/ingest/v1/index.ts
@@ -1,2 +1,4 @@
 export { ingestV1Router } from './ingest';
 export type { IIngestV1RouterConfig } from './ingest';
+export { parseEnrichOpsMode, resolveEnrichOpsMode, prepareIngestOps } from './enrichOps';
+export type { EnrichOpsMode, IPrepareIngestOpsResult } from './enrichOps';

--- a/packages/api/src/routes/ingest/v1/ingest.enrich.test.ts
+++ b/packages/api/src/routes/ingest/v1/ingest.enrich.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Ingest envelope join-gap enrichment — integration (off / shadow / apply).
+ */
+
+import request from 'supertest';
+import express, { type Express } from 'express';
+import { MongoClient, type Db } from 'mongodb';
+import { AuthService } from '@scholaracle/auth';
+import { ingestV1Router } from './ingest';
+import type { EnrichOpsMode } from './enrichOps';
+import { createErrorHandler } from '../../../middleware/errorHandler';
+
+describe('Ingest v1 envelope enrichment', () => {
+  let database: Db;
+  let mongoClient: MongoClient;
+  let userToken: string;
+
+  beforeAll(async () => {
+    const mongodbUri = process.env['MONGODB_URI'] ?? 'mongodb://localhost:27017';
+    const dbName = process.env['MONGODB_DB_NAME'] ?? 'scholaracle_test';
+    mongoClient = new MongoClient(mongodbUri);
+    await mongoClient.connect();
+    database = mongoClient.db(dbName);
+
+    await database.collection('users').deleteMany({ email: 'enrich-ops@test.com' });
+    await database.collection('slc_device_auth').deleteMany({});
+    await database.collection('slc_sources').deleteMany({ sourceId: /^src-enrich-/ });
+    await database.collection('slc_runs').deleteMany({});
+    await database.collection('slc_courses').deleteMany({ 'key.externalId': 'skyward-course-ENR' });
+    await database
+      .collection('slc_attendance_events')
+      .deleteMany({ 'key.externalId': /^att-enrich-/ });
+
+    const authService = new AuthService(database, 'test-secret');
+    const reg = await authService.register('enrich-ops@test.com', 'password123', 'Enrich User');
+    if (!reg.success || !reg.token) throw new Error('Failed to register enrich test user');
+    userToken = reg.token;
+  });
+
+  afterAll(async () => {
+    await mongoClient.close();
+  });
+
+  function makeApp(mode: EnrichOpsMode): Express {
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/api/ingest/v1',
+      ingestV1Router({ database, jwtSecret: 'test-secret', enrichOpsMode: mode })
+    );
+    app.use(createErrorHandler());
+    return app;
+  }
+
+  async function connectorToken(app: Express): Promise<string> {
+    const start = await request(app).post('/api/ingest/v1/device/start').send({});
+    await request(app)
+      .post('/api/ingest/v1/device/approve')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ userCode: start.body.userCode as string });
+    const poll = await request(app)
+      .post('/api/ingest/v1/device/poll')
+      .send({ deviceCode: start.body.deviceCode as string });
+    return poll.body.connectorToken as string;
+  }
+
+  async function uploadGappedEnvelope(
+    app: Express,
+    sourceId: string,
+    attendanceId: string
+  ): Promise<void> {
+    const token = await connectorToken(app);
+    await request(app).post('/api/ingest/v1/sources').set('Authorization', `Bearer ${token}`).send({
+      sourceId,
+      provider: 'skyward',
+      adapterId: 'com.skyward.grade',
+      displayName: 'Enrich Source',
+    });
+    const runRes = await request(app)
+      .post('/api/ingest/v1/runs')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ sourceId });
+    const runId = runRes.body.runId as string;
+    const now = new Date().toISOString();
+    const baseKey = {
+      provider: 'skyward',
+      adapterId: 'com.skyward.grade',
+      studentExternalId: 'stu-enrich',
+      institutionExternalId: 'inst-enrich',
+    };
+    const envelope = {
+      schemaVersion: 'slc.ingest.v1',
+      run: {
+        runId,
+        startedAt: now,
+        provider: 'skyward',
+        adapterId: 'com.skyward.grade',
+        adapterVersion: '1.0.0',
+        mode: 'delta',
+        timezone: 'America/Chicago',
+      },
+      source: { sourceId, displayName: 'Enrich Source' },
+      ops: [
+        {
+          op: 'upsert',
+          entity: 'course',
+          key: { ...baseKey, externalId: 'skyward-course-ENR' },
+          observedAt: now,
+          record: { title: 'ALGEBRA 1', period: '1', teacherName: 'Smith' },
+        },
+        {
+          op: 'upsert',
+          entity: 'attendanceEvent',
+          key: { ...baseKey, externalId: attendanceId },
+          observedAt: now,
+          record: { date: '2026-01-10', status: 'present', periodName: '1' },
+        },
+      ],
+    };
+    const res = await request(app)
+      .post(`/api/ingest/v1/runs/${runId}/envelope`)
+      .set('Authorization', `Bearer ${token}`)
+      .send(envelope);
+    expect(res.status).toBe(200);
+    expect(res.body.accepted).toBe(true);
+  }
+
+  it('off leaves attendance courseExternalId empty', async () => {
+    const app = makeApp('off');
+    await uploadGappedEnvelope(app, 'src-enrich-off', 'att-enrich-off');
+    const doc = await database.collection('slc_attendance_events').findOne({
+      externalId: 'att-enrich-off',
+    });
+    expect(doc).toBeTruthy();
+    const record = doc?.['record'] as Record<string, unknown>;
+    expect(record['courseExternalId']).toBeUndefined();
+  });
+
+  it('shadow leaves attendance courseExternalId empty (does not write patches)', async () => {
+    const app = makeApp('shadow');
+    await uploadGappedEnvelope(app, 'src-enrich-shadow', 'att-enrich-shadow');
+    const doc = await database.collection('slc_attendance_events').findOne({
+      externalId: 'att-enrich-shadow',
+    });
+    expect(doc).toBeTruthy();
+    const record = doc?.['record'] as Record<string, unknown>;
+    expect(record['courseExternalId']).toBeUndefined();
+  });
+
+  it('apply writes attendance courseExternalId from the matching course period', async () => {
+    const app = makeApp('apply');
+    await uploadGappedEnvelope(app, 'src-enrich-apply', 'att-enrich-apply');
+    const doc = await database.collection('slc_attendance_events').findOne({
+      externalId: 'att-enrich-apply',
+    });
+    expect(doc).toBeTruthy();
+    const record = doc?.['record'] as Record<string, unknown>;
+    expect(record['courseExternalId']).toBe('skyward-course-ENR');
+    expect(doc?.['courseExternalId']).toBe('skyward-course-ENR');
+  });
+});

--- a/packages/api/src/routes/ingest/v1/ingest.test.ts
+++ b/packages/api/src/routes/ingest/v1/ingest.test.ts
@@ -265,6 +265,24 @@ describe('Ingest v1 API', () => {
     expect(res.body.error).toMatch(/not found|no credentials/i);
   });
 
+  it('GET /sources/:sourceId/credentials never returns username or password', async () => {
+    // This endpoint exists for OAuth/API-token credentials only.
+    // Even if a legacy login-credential blob somehow exists in the DB, the endpoint must
+    // not leak username or password in the response.
+    const connectorToken = await getConnectorToken();
+    const res = await request(app)
+      .get('/api/ingest/v1/sources/any-source-id/credentials')
+      .set('Authorization', `Bearer ${connectorToken}`);
+    // Either 404 (nothing found) or 410 (gone / portal creds removed) is acceptable.
+    // What is NOT acceptable: a 200 with username/password fields.
+    if (res.status === 200) {
+      expect(res.body).not.toHaveProperty('username');
+      expect(res.body).not.toHaveProperty('password');
+    } else {
+      expect([404, 410]).toContain(res.status);
+    }
+  });
+
   it('returns 400 on source registration with missing fields', async () => {
     const connectorToken = await getConnectorToken();
     const res = await request(app)

--- a/packages/api/src/routes/ingest/v1/ingest.ts
+++ b/packages/api/src/routes/ingest/v1/ingest.ts
@@ -44,12 +44,19 @@ import {
   type IAssignmentMatch,
   type ISourceCourse,
 } from '@scholaracle/connector';
+import { logger } from '../../../logger';
+import { prepareIngestOps, resolveEnrichOpsMode, type EnrichOpsMode } from './enrichOps';
 
 export interface IIngestV1RouterConfig {
   readonly database: Db;
   readonly jwtSecret?: string;
   /** When set, enqueue notify jobs after creating alerts so notifications are delivered. */
   readonly queue?: MongoQueue;
+  /**
+   * Join-gap enrichment mode for envelope ingest. Defaults to ENRICH_OPS_MODE
+   * or `off`. Tests inject this so they do not mutate process.env.
+   */
+  readonly enrichOpsMode?: EnrichOpsMode;
 }
 
 function randomUserCode(): string {
@@ -1302,11 +1309,12 @@ export function ingestV1Router(config: IIngestV1RouterConfig): Router {
           res.status(200).json({ baseUrl, accessToken: credentials.accessToken ?? '' });
           return;
         }
-        res.status(200).json({
-          baseUrl,
-          username: credentials.username,
-          password: credentials.password,
-          accessToken: undefined,
+        // authType was 'login' — portal passwords are no longer vaulted on the server.
+        // Return 410 so callers know this endpoint will never return a portal password.
+        res.status(410).json({
+          success: false,
+          error:
+            'Portal login credentials are no longer stored on the server. Use the mobile app, browser extension, or local CLI to manage school portal credentials.',
         });
         return;
       }
@@ -1405,17 +1413,34 @@ export function ingestV1Router(config: IIngestV1RouterConfig): Router {
         firstStudentExtId
       );
 
+      const prepared = await prepareIngestOps({
+        ops: envelope.ops,
+        mode: resolveEnrichOpsMode(config.enrichOpsMode),
+        revalidate: (ops) => validateEnvelope({ ...envelope, ops }),
+      });
+      logger.info(
+        {
+          runId,
+          enrichOpsMode: prepared.mode,
+          enrichPatchCount: prepared.patchCount,
+          enrichApplied: prepared.applied,
+          enrichFailed: prepared.failed,
+          clientEnrichmentSource: envelope.run.meta?.['enrichmentSource'] ?? 'none',
+        },
+        'ingest envelope enrichment'
+      );
+
       await applyOps({
         database: config.database,
         userId: dataUserId,
         sourceId: envelope.source?.sourceId,
-        ops: envelope.ops,
+        ops: prepared.ops,
       });
 
       await logDataQuality({
         database: config.database,
         userId: dataUserId,
-        ops: envelope.ops,
+        ops: prepared.ops,
       });
 
       const sourceId = envelope.source?.sourceId ?? '';
@@ -1424,7 +1449,7 @@ export function ingestV1Router(config: IIngestV1RouterConfig): Router {
           database: config.database,
           userId: dataUserId,
           sourceId,
-          ops: envelope.ops,
+          ops: prepared.ops,
           provider: envelope.run?.provider ?? 'unknown',
           adapterId: envelope.run?.adapterId ?? 'unknown',
           portalBaseUrl: envelope.source?.portalBaseUrl,

--- a/packages/api/src/routes/integrations/integrations.test.ts
+++ b/packages/api/src/routes/integrations/integrations.test.ts
@@ -450,6 +450,36 @@ describe('Integrations API Routes', () => {
       expect(response.status).toBe(404);
       expect(response.body.success).toBe(false);
     });
+
+    it('rejects authType:login credentials with 400 — server does not store portal passwords', async () => {
+      const createIntRes = await request(app)
+        .post('/api/integrations')
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({
+          provider: 'canvas',
+          adapterId: 'com.instructure.canvas',
+          displayName: 'Canvas Login Reject',
+        });
+      expect(createIntRes.status).toBe(201);
+      const integrationId = createIntRes.body.id as string;
+
+      const createStudentRes = await request(app)
+        .post('/api/students')
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({ name: 'Login Cred Student', grade: 9 });
+      expect(createStudentRes.status).toBe(201);
+      const studentId = createStudentRes.body.id as string;
+
+      const response = await request(app)
+        .post(`/api/integrations/${integrationId}/students/${studentId}`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({
+          credentials: { authType: 'login', username: 'parent', password: 'secret' },
+        });
+
+      expect(response.status).toBe(400);
+      expect(JSON.stringify(response.body)).toMatch(/client|device|app|extension/i);
+    });
   });
 
   describe('DELETE /api/integrations/:id/students/:studentId', () => {

--- a/packages/api/src/routes/integrations/integrations.ts
+++ b/packages/api/src/routes/integrations/integrations.ts
@@ -18,7 +18,7 @@ import {
 } from '@scholaracle/contracts';
 import { asyncHandler } from '../../middleware/asyncHandler';
 import type { IAuthenticatedRequest } from '../../middleware/auth';
-import { encryptCredentials, decryptCredentials } from '../../utils/credentialsCipher';
+import { encryptCredentials } from '../../utils/credentialsCipher';
 import {
   packageSingleFile,
   packageMultiStudent,
@@ -74,8 +74,6 @@ async function testConnectionForProvider(
   baseUrl: string,
   credentials: {
     accessToken?: string;
-    username?: string;
-    password?: string;
     clientId?: string;
     clientSecret?: string;
     apiKey?: string;
@@ -206,7 +204,7 @@ async function testConnectionForProvider(
         return {
           success: false,
           message:
-            'Skyward test connection requires browser-based scraping and is not available via the API. Credentials will be verified during the first sync.',
+            'Skyward uses browser-based extraction on the client device. Use the mobile app, browser extension, or local CLI to connect Skyward.',
           durationMs: Date.now() - start,
         };
       }
@@ -228,16 +226,6 @@ async function testConnectionForProvider(
  * Create integrations router.
  * Account-level integration CRUD and student assignment.
  */
-function parseStoredCredentials(plain: string | null): { username: string; password: string } {
-  if (!plain) return { username: '', password: '' };
-  try {
-    const creds = JSON.parse(plain) as { username?: string; password?: string };
-    return { username: creds.username ?? '', password: creds.password ?? '' };
-  } catch {
-    return { username: '', password: '' };
-  }
-}
-
 /* eslint-disable-next-line max-lines-per-function -- legacy router; refactor in follow-up */
 export function integrationsRouter(config: IIntegrationsRouterConfig): Router {
   const router = Router();
@@ -258,23 +246,14 @@ export function integrationsRouter(config: IIntegrationsRouterConfig): Router {
   ): Promise<PlatformEntry | null> {
     const ingestSource = await ingestSourceRepository.findByUserIdAndSourceId(uid, ds.id);
     if (!ingestSource?.portalBaseUrl) return null;
-    let username = '';
-    let password = '';
-    if (ds.credentials?.encrypted && ds.credentials?.iv) {
-      const plain = decryptCredentials({
-        encrypted: ds.credentials.encrypted,
-        iv: ds.credentials.iv,
-      });
-      const parsed = parseStoredCredentials(plain ?? null);
-      username = parsed.username;
-      password = parsed.password;
-    }
+    // Portal passwords are no longer stored or returned by the server.
+    // Credentials are held by client devices only.
     return {
       studentId: (student._id as { toString?: () => string })?.toString?.() ?? '',
       studentName: student.name,
       platform: ingestSource.provider,
       loginUrl: ingestSource.portalBaseUrl,
-      credentials: { studentName: student.name, username, password },
+      credentials: { studentName: student.name, username: '', password: '' },
     };
   }
   async function getPlatformsForStudent(
@@ -1357,6 +1336,15 @@ echo ""
       }
 
       const bodyParsed = assignStudentSchema.safeParse(req.body || {});
+
+      const rawAuthType = (req.body as { credentials?: { authType?: string } })?.credentials
+        ?.authType;
+      if (rawAuthType === 'login') {
+        throw new ValidationError(
+          'Portal login credentials are stored on the client device (app, extension, or local CLI) and must not be sent to the server.'
+        );
+      }
+
       const credentials =
         bodyParsed.success && bodyParsed.data.credentials ? bodyParsed.data.credentials : undefined;
 

--- a/packages/api/src/routes/integrations/schemas.ts
+++ b/packages/api/src/routes/integrations/schemas.ts
@@ -22,20 +22,13 @@ export type IUpdateIntegrationBody = z.infer<typeof updateIntegrationSchema>;
 export const assignStudentSchema = z.object({
   credentials: z
     .object({
-      authType: z.enum(['api', 'login']),
+      authType: z.enum(['api']),
       accessToken: z.string().optional(),
-      username: z.string().optional(),
-      password: z.string().optional(),
       baseUrl: z.string().optional(),
     })
-    .refine(
-      (data) => {
-        if (data.authType === 'api') return Boolean(data.accessToken?.trim());
-        if (data.authType === 'login') return Boolean(data.username?.trim() && data.password);
-        return false;
-      },
-      { message: 'api requires accessToken; login requires username and password' }
-    )
+    .refine((data) => Boolean(data.accessToken?.trim()), {
+      message: 'api authType requires accessToken',
+    })
     .optional(),
 });
 
@@ -46,10 +39,8 @@ export const testConnectionSchema = z.object({
   adapterId: z.string().min(1, 'adapterId is required'),
   baseUrl: z.string().optional(),
   credentials: z.object({
-    authType: z.enum(['api', 'login', 'oauth2', 'api-key']),
+    authType: z.enum(['api', 'oauth2', 'api-key']),
     accessToken: z.string().optional(),
-    username: z.string().optional(),
-    password: z.string().optional(),
     clientId: z.string().optional(),
     clientSecret: z.string().optional(),
     apiKey: z.string().optional(),

--- a/packages/api/src/routes/oauth/google.ts
+++ b/packages/api/src/routes/oauth/google.ts
@@ -1,29 +1,16 @@
 /**
- * Google Classroom OAuth: authorize redirect and callback to store tokens.
- * GET /api/oauth/google/authorize?studentId=&sourceId= — start flow (auth required)
- * GET /api/oauth/google/callback?code=&state= — exchange code, store credentials (no auth)
+ * Google Classroom OAuth: this flow is discontinued.
+ *
+ * Server-side Classroom data fetching has been removed. School data extraction
+ * is performed exclusively on client devices (mobile app, browser extension, or
+ * local CLI). The server does not store or use OAuth tokens to call Classroom APIs.
+ *
+ * Google Classroom on-device sync is not yet available on mobile. When a client
+ * implementation ships, it will hold the OAuth tokens locally on the device.
  */
 import { Router, type Request, type Response } from 'express';
-import { createHmac } from 'node:crypto';
 import type { Db } from 'mongodb';
-import { StudentRepository } from '@scholaracle/database';
 import type { AuthService } from '@scholaracle/auth';
-import { AuthenticationError, ValidationError } from '@scholaracle/contracts';
-import type { IAuthenticatedRequest } from '../../middleware/auth';
-import { authMiddleware } from '../../middleware/auth';
-import { asyncHandler } from '../../middleware/asyncHandler';
-import { encryptCredentials } from '../../utils/credentialsCipher';
-
-const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
-const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
-const SCOPES = [
-  'https://www.googleapis.com/auth/classroom.courses.readonly',
-  'https://www.googleapis.com/auth/classroom.coursework.students.readonly',
-  'https://www.googleapis.com/auth/classroom.student-submissions.students.readonly',
-  'openid',
-  'email',
-  'profile',
-].join(' ');
 
 export interface IGoogleOAuthConfig {
   readonly database: Db;
@@ -32,181 +19,19 @@ export interface IGoogleOAuthConfig {
   readonly authService: AuthService;
 }
 
-function getUserId(req: Request): string | null {
-  return (req as IAuthenticatedRequest).userId ?? null;
-}
-
-function signState(
-  payload: { studentId: string; sourceId: string; userId: string },
-  secret: string
-): string {
-  const json = JSON.stringify(payload);
-  const b64 = Buffer.from(json, 'utf8').toString('base64url');
-  const sig = createHmac('sha256', secret).update(json).digest('base64url');
-  return `${b64}.${sig}`;
-}
-
-function verifyState(
-  state: string,
-  secret: string
-): { studentId: string; sourceId: string; userId: string } | null {
-  const dot = state.indexOf('.');
-  if (dot <= 0) return null;
-  const b64 = state.slice(0, dot);
-  const sig = state.slice(dot + 1);
-  let json: string;
-  try {
-    json = Buffer.from(b64, 'base64url').toString('utf8');
-  } catch {
-    return null;
-  }
-  const expected = createHmac('sha256', secret).update(json).digest('base64url');
-  if (sig !== expected) return null;
-  try {
-    return JSON.parse(json) as { studentId: string; sourceId: string; userId: string };
-  } catch {
-    return null;
-  }
-}
-
-export function createGoogleOAuthRouter(config: IGoogleOAuthConfig): Router {
+export function createGoogleOAuthRouter(_config: IGoogleOAuthConfig): Router {
   const router = Router();
-  const { database, jwtSecret, baseUrl, authService } = config;
-  const studentRepository = new StudentRepository(database);
 
-  /**
-   * GET /api/oauth/google/authorize?studentId=&sourceId=
-   * Requires auth. Redirects to Google consent with state = signed(studentId, sourceId, userId).
-   */
-  router.get('/google/authorize', authMiddleware(authService), (req: Request, res: Response) => {
-    const userId = getUserId(req);
-    if (!userId) {
-      throw new AuthenticationError('Unauthorized');
-    }
-    const studentId = req.query['studentId'] as string | undefined;
-    const sourceId = req.query['sourceId'] as string | undefined;
-    if (!studentId || !sourceId) {
-      throw new ValidationError('Missing studentId or sourceId');
-    }
-    const clientId = process.env['GOOGLE_CLASSROOM_CLIENT_ID'];
-    if (!clientId) {
-      // Deliberate 503: OAuth not configured (no matching AppError class).
-      res.status(503).json({ success: false, error: 'Google Classroom OAuth is not configured' });
-      return;
-    }
-    const redirectUri = `${baseUrl.replace(/\/$/, '')}/api/oauth/google/callback`;
-    const state = signState({ studentId, sourceId, userId }, jwtSecret);
-    const url = new URL(GOOGLE_AUTH_URL);
-    url.searchParams.set('client_id', clientId);
-    url.searchParams.set('redirect_uri', redirectUri);
-    url.searchParams.set('response_type', 'code');
-    url.searchParams.set('scope', SCOPES);
-    url.searchParams.set('state', state);
-    url.searchParams.set('access_type', 'offline');
-    url.searchParams.set('prompt', 'consent');
-    const returnUrl = req.query['returnUrl'] === 'true' || req.query['returnUrl'] === '1';
-    if (returnUrl) {
-      res.json({ url: url.toString() });
-      return;
-    }
-    res.redirect(302, url.toString());
-  });
+  const discontinued = (_req: Request, res: Response): void => {
+    res.status(410).json({
+      success: false,
+      error:
+        'Google Classroom server-side sync has been discontinued. School data extraction runs on the client device only. Google Classroom sync via the mobile app will be available in a future release.',
+    });
+  };
 
-  /**
-   * GET /api/oauth/google/callback?code=&state=
-   * Exchanges code for tokens, encrypts and stores on student data source, redirects to success.
-   */
-  // Browser-facing OAuth callback: error responses are redirects / plain-text by design.
-  router.get(
-    '/google/callback',
-    asyncHandler(async (req: Request, res: Response) => {
-      const code = req.query['code'] as string | undefined;
-      const state = req.query['state'] as string | undefined;
-      const errorParam = req.query['error'] as string | undefined;
-      if (errorParam) {
-        res.redirect(
-          302,
-          `${baseUrl.replace(/\/$/, '')}/dashboard?oauth=error&message=${encodeURIComponent(errorParam)}`
-        );
-        return;
-      }
-      if (!code || !state) {
-        res.status(400).send('Missing code or state');
-        return;
-      }
-      const payload = verifyState(state, jwtSecret);
-      if (!payload) {
-        res.status(400).send('Invalid or expired state');
-        return;
-      }
-      const clientId = process.env['GOOGLE_CLASSROOM_CLIENT_ID'];
-      const clientSecret = process.env['GOOGLE_CLASSROOM_CLIENT_SECRET'];
-      if (!clientId || !clientSecret) {
-        res.status(503).send('Google Classroom OAuth is not configured');
-        return;
-      }
-      const redirectUri = `${baseUrl.replace(/\/$/, '')}/api/oauth/google/callback`;
-      const tokenRes = await fetch(GOOGLE_TOKEN_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({
-          code,
-          client_id: clientId,
-          client_secret: clientSecret,
-          redirect_uri: redirectUri,
-          grant_type: 'authorization_code',
-        }),
-      });
-      if (!tokenRes.ok) {
-        const errText = await tokenRes.text();
-        res.redirect(
-          302,
-          `${baseUrl.replace(/\/$/, '')}/dashboard?oauth=error&message=${encodeURIComponent(errText.slice(0, 100))}`
-        );
-        return;
-      }
-      const tokenBody = (await tokenRes.json()) as {
-        access_token?: string;
-        refresh_token?: string;
-        expires_in?: number;
-      };
-      const accessToken = tokenBody.access_token;
-      const refreshToken = tokenBody.refresh_token;
-      if (!accessToken) {
-        res.redirect(
-          302,
-          `${baseUrl.replace(/\/$/, '')}/dashboard?oauth=error&message=no_access_token`
-        );
-        return;
-      }
-      const student = await studentRepository.findById(payload.studentId);
-      if (!student || !student.hasAccess(payload.userId)) {
-        res.status(404).send('Student not found');
-        return;
-      }
-      const idx = student.dataSources.findIndex((ds) => ds.id === payload.sourceId);
-      if (idx === -1) {
-        res.status(404).send('Source not found');
-        return;
-      }
-      const credentials = {
-        authType: 'api' as const,
-        accessToken,
-        ...(refreshToken && { refreshToken }),
-      };
-      const plain = JSON.stringify(credentials);
-      const encrypted = encryptCredentials(plain);
-      if (!encrypted) {
-        res.status(503).send('Credential encryption is not configured');
-        return;
-      }
-      const dataSourcesUpdated = student.dataSources.map((d, i) =>
-        i === idx ? { ...d, credentials: { encrypted: encrypted.encrypted, iv: encrypted.iv } } : d
-      );
-      await studentRepository.update(payload.studentId, { dataSources: dataSourcesUpdated });
-      res.redirect(302, `${baseUrl.replace(/\/$/, '')}/dashboard?oauth=google_success`);
-    })
-  );
+  router.get('/google/authorize', discontinued);
+  router.get('/google/callback', discontinued);
 
   return router;
 }

--- a/packages/api/src/routes/source-invites/source-invites.test.ts
+++ b/packages/api/src/routes/source-invites/source-invites.test.ts
@@ -1,0 +1,258 @@
+/**
+ * SOURCE_INVITE.md §6
+ */
+
+import request from 'supertest';
+import express, { type Express } from 'express';
+import { MongoClient, type Db } from 'mongodb';
+import { AuthService } from '@scholaracle/auth';
+import {
+  SOURCE_INVITE_ISSUE_RESPONSE_KEYS,
+  SOURCE_INVITE_REDEEM_ERROR,
+} from '@scholaracle/contracts';
+import { StudentRepository, SourceInviteRepository } from '@scholaracle/database';
+import { createErrorHandler } from '../../middleware/errorHandler';
+import { authMiddleware } from '../../middleware/auth';
+import { MemoryRateLimiter } from '../../middleware/rateLimit';
+import { SystemClock } from '../../services/source-invite/clock';
+import { InstallLandingRenderer } from '../../services/source-invite/InstallLandingRenderer';
+import { SourceInviteService } from '../../services/source-invite/SourceInviteService';
+import { StudentRepositoryOwnerLookup } from '../../services/source-invite/studentOwnerLookup';
+import { CryptoTokenGenerator, Sha256TokenHasher } from '../../services/source-invite/tokens';
+import type { ISourceInviteMailer } from '../../services/source-invite/SourceInviteEmailSender';
+import { installSourceRouter, sourceInvitesRouter } from './source-invites';
+
+describe('source-invites HTTP', () => {
+  let app: Express;
+  let database: Db;
+  let mongoClient: MongoClient;
+  let authService: AuthService;
+  let userToken: string;
+  let otherToken: string;
+  let studentId: string;
+  let mailer: { sendInstallLink: jest.Mock };
+  let limiter: MemoryRateLimiter;
+
+  beforeAll(async () => {
+    const mongodbUri = process.env['MONGODB_URI'] ?? 'mongodb://localhost:27017';
+    mongoClient = new MongoClient(mongodbUri);
+    await mongoClient.connect();
+    database = mongoClient.db('scholaracle_source_invite_http_test');
+    authService = new AuthService(database, 'test-secret');
+  });
+
+  afterAll(async () => {
+    await mongoClient.close();
+  });
+
+  beforeEach(async () => {
+    await database.collection('users').deleteMany({});
+    await database.collection('students').deleteMany({});
+    await database.collection('source_invites').deleteMany({});
+
+    const a = await authService.register('parent@example.com', 'password123', 'Parent A');
+    if (!a.success || !a.token || !a.user) throw new Error('register A failed');
+    userToken = a.token;
+    const b = await authService.register('other@example.com', 'password123', 'Parent B');
+    if (!b.success || !b.token) throw new Error('register B failed');
+    otherToken = b.token;
+
+    const students = new StudentRepository(database);
+    const created = await students.create({
+      userId: a.user.id,
+      name: 'Ava Lewis',
+      studentId: 'ava-lewis',
+    });
+    studentId = created._id!.toString();
+
+    mailer = { sendInstallLink: jest.fn().mockResolvedValue(undefined) };
+    limiter = new MemoryRateLimiter();
+    const store = new SourceInviteRepository(database);
+    const service = new SourceInviteService(
+      store,
+      new SystemClock(),
+      new CryptoTokenGenerator(),
+      new Sha256TokenHasher(),
+      new StudentRepositoryOwnerLookup(students)
+    );
+    const config = {
+      issuer: service,
+      redeemer: service,
+      mailer: mailer as unknown as ISourceInviteMailer,
+      landing: new InstallLandingRenderer(),
+      apiPublicOrigin: 'https://api.example.com',
+      webOrigin: 'https://app.example.com',
+      limiter,
+    };
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/source-invites', authMiddleware(authService), sourceInvitesRouter(config));
+    app.use('/install-source', installSourceRouter(config));
+    app.use(createErrorHandler());
+  });
+
+  it('unauthenticated issue/redeem → 401', async () => {
+    await request(app)
+      .post('/api/source-invites')
+      .send({ studentId, provider: 'skyward', portalBaseUrl: 'https://skyward.iscorp.com' })
+      .expect(401);
+    await request(app)
+      .post('/api/source-invites/redeem')
+      .send({ token: 'ab'.repeat(32) })
+      .expect(401);
+  });
+
+  it('issue body with to → 400', async () => {
+    const res = await request(app)
+      .post('/api/source-invites')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        to: 'victim@x.com',
+        studentId,
+        provider: 'skyward',
+        portalBaseUrl: 'https://skyward.iscorp.com',
+      });
+    expect(res.status).toBe(400);
+  });
+
+  it('issue body with password → 400', async () => {
+    const res = await request(app)
+      .post('/api/source-invites')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        studentId,
+        provider: 'skyward',
+        portalBaseUrl: 'https://skyward.iscorp.com',
+        password: 'secret',
+      });
+    expect(res.status).toBe(400);
+  });
+
+  it('happy issue → 200 exact keys; mailer got landing URL; JSON has no raw token', async () => {
+    const res = await request(app)
+      .post('/api/source-invites')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        studentId,
+        provider: 'skyward',
+        portalBaseUrl: 'https://skyward.iscorp.com',
+      });
+    expect(res.status).toBe(200);
+    expect(Object.keys(res.body).sort()).toEqual([...SOURCE_INVITE_ISSUE_RESPONSE_KEYS].sort());
+    expect(res.body.emailedTo).toBe('parent@example.com');
+    expect(JSON.stringify(res.body)).not.toMatch(/"token"/);
+    expect(mailer.sendInstallLink).toHaveBeenCalledTimes(1);
+    const mailArg = mailer.sendInstallLink.mock.calls[0]?.[0] as { landingUrl: string };
+    expect(mailArg.landingUrl).toMatch(
+      /^https:\/\/api\.example\.com\/install-source\?t=[a-f0-9]{64}$/
+    );
+    expect(mailArg.landingUrl).not.toContain('password');
+  });
+
+  it('redeem happy → Ava portal URL', async () => {
+    await request(app)
+      .post('/api/source-invites')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        studentId,
+        provider: 'skyward',
+        portalBaseUrl: 'https://skyward.iscorp.com',
+      })
+      .expect(200);
+    const mailArg = mailer.sendInstallLink.mock.calls[0]?.[0] as { landingUrl: string };
+    const token = mailArg.landingUrl.split('t=')[1] ?? '';
+    const redeem = await request(app)
+      .post('/api/source-invites/redeem')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ token });
+    expect(redeem.status).toBe(200);
+    expect(redeem.body.invite.portalBaseUrl).toBe('https://skyward.iscorp.com');
+    expect(redeem.body.invite.provider).toBe('skyward');
+  });
+
+  it('redeem as other user → 404 generic error string', async () => {
+    await request(app)
+      .post('/api/source-invites')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        studentId,
+        provider: 'skyward',
+        portalBaseUrl: 'https://skyward.iscorp.com',
+      })
+      .expect(200);
+    const mailArg = mailer.sendInstallLink.mock.calls[0]?.[0] as { landingUrl: string };
+    const token = mailArg.landingUrl.split('t=')[1] ?? '';
+    const redeem = await request(app)
+      .post('/api/source-invites/redeem')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ token });
+    expect(redeem.status).toBe(404);
+    expect(redeem.body.error).toBe(SOURCE_INVITE_REDEEM_ERROR);
+  });
+
+  it('rate limit 6th issue → 429', async () => {
+    const body = {
+      studentId,
+      provider: 'skyward',
+      portalBaseUrl: 'https://skyward.iscorp.com',
+    };
+    for (let i = 0; i < 5; i += 1) {
+      const res = await request(app)
+        .post('/api/source-invites')
+        .set('Authorization', `Bearer ${userToken}`)
+        .send(body);
+      expect(res.status).toBe(200);
+    }
+    const sixth = await request(app)
+      .post('/api/source-invites')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send(body);
+    expect(sixth.status).toBe(429);
+  });
+});
+
+describe('GET /install-source', () => {
+  const landing = new InstallLandingRenderer();
+  const app = express();
+  app.use(
+    '/install-source',
+    installSourceRouter({
+      issuer: {} as never,
+      redeemer: {} as never,
+      mailer: { sendInstallLink: async (): Promise<void> => undefined },
+      landing,
+      apiPublicOrigin: 'https://api.example.com',
+      webOrigin: 'https://app.example.com',
+    })
+  );
+
+  const hex = 'ab'.repeat(32);
+
+  it('GET without t → 200 html with both links', async () => {
+    const res = await request(app).get('/install-source');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/html/);
+    expect(res.text).toContain('scholarmancy://install-source');
+    expect(res.text).toContain('/dashboard/install-source');
+  });
+
+  it('GET with 64 hex → both hrefs contain that hex only as t', async () => {
+    const res = await request(app).get(`/install-source?t=${hex}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain(`scholarmancy://install-source?t=${hex}`);
+    expect(res.text).toContain(`https://app.example.com/dashboard/install-source?t=${hex}`);
+  });
+
+  it('GET with script → 200, html does not contain script', async () => {
+    const res = await request(app).get('/install-source?t=<script>alert(1)</script>');
+    expect(res.status).toBe(200);
+    expect(res.text.toLowerCase()).not.toContain('script');
+  });
+
+  it('html does not contain password or iscorp', async () => {
+    const res = await request(app).get(`/install-source?t=${hex}`);
+    expect(res.text.toLowerCase()).not.toContain('password');
+    expect(res.text).not.toContain('iscorp');
+  });
+});

--- a/packages/api/src/routes/source-invites/source-invites.ts
+++ b/packages/api/src/routes/source-invites/source-invites.ts
@@ -1,0 +1,120 @@
+/**
+ * SOURCE_INVITE.md §6
+ */
+
+import { Router, type Request, type Response } from 'express';
+import {
+  RateLimitError,
+  ValidationError,
+  assertNoSecrets,
+  type ISourceInviteIssueRequest,
+  type ISourceInviteIssueResponse,
+  type ISourceInviteRedeemResponse,
+} from '@scholaracle/contracts';
+import { asyncHandler } from '../../middleware/asyncHandler';
+import type { IAuthenticatedRequest } from '../../middleware/auth';
+import type { IRateLimiter } from '../../middleware/rateLimit';
+import type { IInstallLandingRenderer } from '../../services/source-invite/InstallLandingRenderer';
+import type { ISourceInviteMailer } from '../../services/source-invite/SourceInviteEmailSender';
+import type {
+  ISourceInviteIssuer,
+  ISourceInviteRedeemer,
+} from '../../services/source-invite/SourceInviteService';
+
+export interface ISourceInviteRouterConfig {
+  readonly issuer: ISourceInviteIssuer;
+  readonly redeemer: ISourceInviteRedeemer;
+  readonly mailer: ISourceInviteMailer;
+  readonly landing: IInstallLandingRenderer;
+  readonly apiPublicOrigin: string;
+  readonly webOrigin: string;
+  readonly limiter?: IRateLimiter;
+}
+
+function stripSlash(origin: string): string {
+  return origin.replace(/\/+$/, '');
+}
+
+function asRecord(body: unknown): Record<string, unknown> {
+  if (body !== null && typeof body === 'object' && !Array.isArray(body)) {
+    return body as Record<string, unknown>;
+  }
+  return {};
+}
+
+export function sourceInvitesRouter(config: ISourceInviteRouterConfig): Router {
+  const router = Router();
+
+  router.post(
+    '/',
+    asyncHandler(async (req: Request, res: Response): Promise<void> => {
+      const authReq = req as IAuthenticatedRequest;
+      const userId = authReq.userId;
+      const userEmail = authReq.userEmail;
+      if (!userId || !userEmail) {
+        throw new ValidationError('Authentication required');
+      }
+      if (config.limiter) {
+        const limited = config.limiter.consume(`source-invite:${userId}`, 60 * 60 * 1000, 5);
+        if (!limited.allowed) {
+          throw new RateLimitError();
+        }
+      }
+      const body = asRecord(req.body);
+      if (Object.prototype.hasOwnProperty.call(body, 'to')) {
+        throw new ValidationError('Install links are emailed to your account only');
+      }
+      assertNoSecrets(body);
+      const request: ISourceInviteIssueRequest = {
+        studentId: String(body['studentId'] ?? ''),
+        provider: body['provider'] as ISourceInviteIssueRequest['provider'],
+        portalBaseUrl: String(body['portalBaseUrl'] ?? ''),
+        ...(typeof body['displayName'] === 'string' ? { displayName: body['displayName'] } : {}),
+      };
+      const issued = await config.issuer.issue({ userId, request });
+      const landingUrl = `${stripSlash(config.apiPublicOrigin)}/install-source?t=${issued.token}`;
+      await config.mailer.sendInstallLink({
+        to: userEmail,
+        providerName: issued.providerName,
+        studentName: issued.studentName,
+        landingUrl,
+        expiresAt: issued.expiresAt,
+      });
+      const payload: ISourceInviteIssueResponse = {
+        success: true,
+        expiresAt: issued.expiresAt.toISOString(),
+        emailedTo: userEmail,
+      };
+      res.status(200).json(payload);
+    })
+  );
+
+  router.post(
+    '/redeem',
+    asyncHandler(async (req: Request, res: Response): Promise<void> => {
+      const authReq = req as IAuthenticatedRequest;
+      const userId = authReq.userId;
+      if (!userId) {
+        throw new ValidationError('Authentication required');
+      }
+      const body = asRecord(req.body);
+      assertNoSecrets(body, { allowKeys: new Set(['token']) });
+      const token = typeof body['token'] === 'string' ? body['token'] : '';
+      const invite = await config.redeemer.redeem({ userId, token });
+      const payload: ISourceInviteRedeemResponse = { success: true, invite };
+      res.status(200).json(payload);
+    })
+  );
+
+  return router;
+}
+
+export function installSourceRouter(config: ISourceInviteRouterConfig): Router {
+  const router = Router();
+  router.get('/', (req: Request, res: Response): void => {
+    const raw = typeof req.query['t'] === 'string' ? req.query['t'] : '';
+    const html = config.landing.render({ tokenHex: raw, webOrigin: config.webOrigin });
+    res.status(200).type('html').send(html);
+  });
+  return router;
+}

--- a/packages/api/src/routes/students/schemas.ts
+++ b/packages/api/src/routes/students/schemas.ts
@@ -17,22 +17,18 @@ export const updateSourceSchema = addSourceSchema.partial().extend({
 
 export type IUpdateSourceBody = z.infer<typeof updateSourceSchema>;
 
-/** Credentials for API (token) or login (username/password) to scrape. */
+/**
+ * Credentials for API (OAuth token) only. Portal username/password (authType:'login') is
+ * rejected — school portal credentials are held by client devices, never by the server.
+ */
 export const credentialsSchema = z
   .object({
-    authType: z.enum(['api', 'login']),
+    authType: z.enum(['api']),
     accessToken: z.string().optional(),
-    username: z.string().optional(),
-    password: z.string().optional(),
     baseUrl: z.string().optional(),
   })
-  .refine(
-    (data) => {
-      if (data.authType === 'api') return Boolean(data.accessToken?.trim());
-      if (data.authType === 'login') return Boolean(data.username?.trim() && data.password);
-      return false;
-    },
-    { message: 'api requires accessToken; login requires username and password' }
-  );
+  .refine((data) => Boolean(data.accessToken?.trim()), {
+    message: 'api authType requires accessToken',
+  });
 
 export type ICredentialsBody = z.infer<typeof credentialsSchema>;

--- a/packages/api/src/routes/students/students.idor.test.ts
+++ b/packages/api/src/routes/students/students.idor.test.ts
@@ -309,8 +309,9 @@ describe('Students route — owner-scoped gradebook IDOR', () => {
       .get(`/api/students/${studentId}/grades`)
       .set('Authorization', `Bearer ${owner.token}`);
     expect(res.status).toBe(200);
-    // At least one course should be present
-    expect(Array.isArray(res.body.courses) || Array.isArray(res.body)).toBe(true);
+    // GET /grades returns IStudentGradesResponse.courseGrades, not a top-level `courses` array.
+    expect(Array.isArray(res.body.courseGrades)).toBe(true);
+    expect(res.body.courseGrades.length).toBeGreaterThan(0);
   });
 
   it('accepted co-parent sees owner grades (not empty)', async () => {
@@ -318,7 +319,7 @@ describe('Students route — owner-scoped gradebook IDOR', () => {
       .get(`/api/students/${studentId}/grades`)
       .set('Authorization', `Bearer ${coParent.token}`);
     expect(res.status).toBe(200);
-    const courses: unknown[] = res.body.courses ?? res.body ?? [];
+    const courses: unknown[] = res.body.courseGrades ?? [];
     expect(courses.length).toBeGreaterThan(0);
   });
 

--- a/packages/api/src/routes/students/students.test.ts
+++ b/packages/api/src/routes/students/students.test.ts
@@ -1429,4 +1429,67 @@ describe('Students API Routes', () => {
       }
     });
   });
+
+  describe('PUT /api/students/:id/sources/:sourceId/credentials — portal login rejected', () => {
+    it('rejects authType:login with 400 (portal passwords not accepted by server)', async () => {
+      if (!database) return;
+      const createRes = await request(app)
+        .post('/api/students')
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({ name: 'Cred Test Student' });
+      expect(createRes.status).toBe(201);
+      const studentId = createRes.body.id as string;
+
+      const addRes = await request(app)
+        .post(`/api/students/${studentId}/sources`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({
+          provider: 'canvas',
+          adapterId: 'com.instructure.canvas',
+          displayName: 'Canvas',
+          portalBaseUrl: 'https://school.instructure.com',
+          dataTypes: ['grades'],
+        });
+      expect(addRes.status).toBe(201);
+      const sourceId = addRes.body.id as string;
+
+      const res = await request(app)
+        .put(`/api/students/${studentId}/sources/${sourceId}/credentials`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({ authType: 'login', username: 'parent', password: 'secret' });
+
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.body)).toMatch(/client|device|app|extension/i);
+    });
+
+    it('rejects authType:login for skyward with 400', async () => {
+      if (!database) return;
+      const createRes = await request(app)
+        .post('/api/students')
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({ name: 'Skyward Cred Student' });
+      expect(createRes.status).toBe(201);
+      const studentId = createRes.body.id as string;
+
+      const addRes = await request(app)
+        .post(`/api/students/${studentId}/sources`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({
+          provider: 'skyward',
+          adapterId: 'com.skyward.iscorp',
+          displayName: 'Skyward',
+          portalBaseUrl: 'https://school.skyward.com',
+          dataTypes: ['grades'],
+        });
+      expect(addRes.status).toBe(201);
+      const sourceId = addRes.body.id as string;
+
+      const res = await request(app)
+        .put(`/api/students/${studentId}/sources/${sourceId}/credentials`)
+        .set('Authorization', `Bearer ${testToken}`)
+        .send({ authType: 'login', username: 'parent', password: 'secret' });
+
+      expect(res.status).toBe(400);
+    });
+  });
 });

--- a/packages/api/src/routes/students/students.ts
+++ b/packages/api/src/routes/students/students.ts
@@ -3247,7 +3247,8 @@ export function studentsRouter(config: IStudentsRouterConfig): Router {
 
   /**
    * PUT /api/students/:id/sources/:sourceId/credentials
-   * Set or update credentials for a source (API token or login for scraping). Stored encrypted.
+   * Set or update API-token credentials for a source. Portal username/password (authType:'login')
+   * is never accepted — school credentials are stored on the client device only.
    */
   router.put(
     '/:id/sources/:sourceId/credentials',
@@ -3260,6 +3261,13 @@ export function studentsRouter(config: IStudentsRouterConfig): Router {
       if (!studentId || !sourceId) {
         throw new ValidationError('Missing student ID or source ID');
       }
+
+      if ((req.body as { authType?: string })?.authType === 'login') {
+        throw new ValidationError(
+          'Portal login credentials are stored on the client device (app, extension, or local CLI) and must not be sent to the server.'
+        );
+      }
+
       const parsed = credentialsSchema.safeParse(req.body);
       if (!parsed.success) {
         throw ValidationError.fromZod(parsed.error);

--- a/packages/api/src/routes/sync/sync.test.ts
+++ b/packages/api/src/routes/sync/sync.test.ts
@@ -190,17 +190,20 @@ describe('Sync API Routes', () => {
       expect(response.body.error).toContain('no data sources');
     });
 
-    it('should return 200 and enqueue sync jobs for owner', async () => {
+    it('should return 200 and enqueue sync jobs for owner (non-portal providers)', async () => {
       const studentId = new ObjectId();
       await database.collection('students').insertOne({
         _id: studentId,
         userId: testUserId,
         name: 'My Student',
         dataSources: [
-          { pluginId: 'canvas::default', config: { institutionUrl: 'https://canvas.example.com' } },
           {
-            pluginId: 'skyward::default',
-            config: { institutionUrl: 'https://skyward.example.com' },
+            pluginId: 'custom-provider-a::default',
+            config: { institutionUrl: 'https://provider-a.example.com' },
+          },
+          {
+            pluginId: 'custom-provider-b::default',
+            config: { institutionUrl: 'https://provider-b.example.com' },
           },
         ],
       });
@@ -216,7 +219,8 @@ describe('Sync API Routes', () => {
       expect(mockTriggerAllForStudent).toHaveBeenCalledWith(
         studentId.toString(),
         testUserId,
-        expect.any(Array)
+        expect.any(Array),
+        expect.anything()
       );
     });
   });
@@ -272,14 +276,17 @@ describe('Sync API Routes', () => {
       expect(response.body.error).toContain('not found');
     });
 
-    it('should return 200 and enqueue single source sync', async () => {
+    it('should return 200 and enqueue single source sync (non-portal provider)', async () => {
       const studentId = new ObjectId();
       await database.collection('students').insertOne({
         _id: studentId,
         userId: testUserId,
         name: 'Student',
         dataSources: [
-          { pluginId: 'canvas::default', config: { institutionUrl: 'https://canvas.example.com' } },
+          {
+            pluginId: 'custom-district-api::default',
+            config: { institutionUrl: 'https://district.api.example.com' },
+          },
         ],
       });
       const response = await request(app)
@@ -295,11 +302,104 @@ describe('Sync API Routes', () => {
         expect.objectContaining({
           studentId: studentId.toString(),
           dataSourceIndex: 0,
-          provider: 'canvas',
-          adapterId: 'canvas::default',
+          provider: 'custom-district-api',
+          adapterId: 'custom-district-api::default',
           userId: testUserId,
         })
       );
+    });
+
+    it('rejects sync trigger for HTML portal providers (canvas/skyward/aeries) with 400', async () => {
+      const studentId = new ObjectId();
+      await database.collection('students').insertOne({
+        _id: studentId,
+        userId: testUserId,
+        name: 'Canvas Student',
+        dataSources: [
+          {
+            id: 'src-canvas',
+            pluginId: 'canvas::default',
+            config: { institutionUrl: 'https://canvas.example.com' },
+          },
+        ],
+      });
+
+      const res = await request(app)
+        .post(`/api/sync/students/${studentId}/0`)
+        .set('Authorization', `Bearer ${testToken}`);
+
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.body)).toMatch(/client|device|app|extension/i);
+      expect(mockTriggerNow).not.toHaveBeenCalled();
+    });
+
+    it('rejects sync trigger for skyward with 400', async () => {
+      const studentId = new ObjectId();
+      await database.collection('students').insertOne({
+        _id: studentId,
+        userId: testUserId,
+        name: 'Skyward Student',
+        dataSources: [
+          {
+            id: 'src-skyward',
+            pluginId: 'skyward::default',
+            config: { institutionUrl: 'https://skyward.example.com' },
+          },
+        ],
+      });
+
+      const res = await request(app)
+        .post(`/api/sync/students/${studentId}/0`)
+        .set('Authorization', `Bearer ${testToken}`);
+
+      expect(res.status).toBe(400);
+      expect(mockTriggerNow).not.toHaveBeenCalled();
+    });
+
+    it('rejects sync trigger for google-classroom with 400', async () => {
+      const studentId = new ObjectId();
+      await database.collection('students').insertOne({
+        _id: studentId,
+        userId: testUserId,
+        name: 'Classroom Student',
+        dataSources: [
+          {
+            id: 'src-gc',
+            pluginId: 'google-classroom::default',
+            config: { institutionUrl: 'https://classroom.googleapis.com' },
+          },
+        ],
+      });
+
+      const res = await request(app)
+        .post(`/api/sync/students/${studentId}/0`)
+        .set('Authorization', `Bearer ${testToken}`);
+
+      expect(res.status).toBe(400);
+      expect(mockTriggerNow).not.toHaveBeenCalled();
+    });
+
+    it('rejects sync trigger for oneroster with 400', async () => {
+      const studentId = new ObjectId();
+      await database.collection('students').insertOne({
+        _id: studentId,
+        userId: testUserId,
+        name: 'OneRoster Student',
+        dataSources: [
+          {
+            id: 'src-or',
+            pluginId: 'oneroster::default',
+            config: { institutionUrl: 'https://oneroster.example.com' },
+          },
+        ],
+      });
+
+      const res = await request(app)
+        .post(`/api/sync/students/${studentId}/0`)
+        .set('Authorization', `Bearer ${testToken}`);
+
+      expect(res.status).toBe(400);
+      expect(mockTriggerNow).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/api/src/routes/sync/sync.ts
+++ b/packages/api/src/routes/sync/sync.ts
@@ -150,6 +150,13 @@ export function createSyncRouter(config: ISyncRouterConfig): Router {
       if (!ds) throw new NotFoundError(`Data source at index ${idx} not found`);
 
       const provider = ds.pluginId.split('::')[0] ?? ds.pluginId;
+
+      if (['canvas', 'skyward', 'aeries', 'google-classroom', 'oneroster'].includes(provider)) {
+        throw new ValidationError(
+          `${provider} sync runs on the client device (mobile app, browser extension, or local CLI), not on the server. Trigger a sync from the Scholarmancy app or run npx scholaracle-scraper run.`
+        );
+      }
+
       const jobId = await syncScheduler.triggerNow({
         studentId: studentId!,
         dataSourceIndex: idx,

--- a/packages/api/src/scripts/ensure-owner-scope-schema.ts
+++ b/packages/api/src/scripts/ensure-owner-scope-schema.ts
@@ -106,10 +106,11 @@ async function main(): Promise<void> {
       for (const sp of shared) {
         const coparentId = sp.userId!;
         for (const collName of SLC_COLLECTIONS) {
-          const query: Record<string, unknown> = { userId: coparentId };
-          if (studentExternalId && collName !== 'slc_sources' && collName !== 'slc_runs') {
-            query['studentExternalId'] = studentExternalId;
-          }
+          const scopedToStudent =
+            Boolean(studentExternalId) && collName !== 'slc_sources' && collName !== 'slc_runs';
+          const query: Record<string, unknown> = scopedToStudent
+            ? { userId: coparentId, studentExternalId }
+            : { userId: coparentId };
           coparentKeyedRows += await db.collection(collName).countDocuments(query);
         }
       }

--- a/packages/api/src/scripts/purge-server-portal-passwords.ts
+++ b/packages/api/src/scripts/purge-server-portal-passwords.ts
@@ -1,84 +1,81 @@
 /* eslint-disable no-console -- CLI script: console output is its interface */
 /**
- * One-off migration: delete server-stored portal passwords for Canvas/Skyward/Aeries
- * after the account has at least one successful client-side run (meta.clientType set).
+ * Migration: purge server-stored encrypted credential blobs for all portal providers.
  *
- * Usage (from packages/api or workers with MONGODB_URI):
+ * The server no longer accepts, stores, or uses school portal credentials
+ * (canvas, skyward, aeries, google-classroom, oneroster). This script unsets
+ * the `dataSources[n].credentials` field for any data source whose provider
+ * matches these providers.
+ *
+ * Data stored as `{ encrypted, iv }` (AES-256-GCM blobs) — never log or
+ * output credential values.
+ *
+ * Usage (from packages/api with MONGODB_URI set):
  *   npx ts-node src/scripts/purge-server-portal-passwords.ts --dry-run
  *   npx ts-node src/scripts/purge-server-portal-passwords.ts --apply
  *
- * Never logs credential values.
+ * Run on UAT first, then production.
  */
 
 import { MongoClient } from 'mongodb';
 
-const PORTAL_PROVIDERS = new Set(['canvas', 'skyward', 'aeries']);
+const PURGE_PROVIDERS = new Set(['canvas', 'skyward', 'aeries', 'google-classroom', 'oneroster']);
 
 async function main(): Promise<void> {
   const apply = process.argv.includes('--apply');
   const uri = process.env['MONGODB_URI'];
   const dbName = process.env['MONGODB_DB_NAME'] ?? 'scholaracle';
-  if (!uri) throw new Error('MONGODB_URI required');
+  if (!uri) throw new Error('MONGODB_URI is required');
 
   const client = new MongoClient(uri);
   await client.connect();
-  const db = client.db(dbName);
+  try {
+    const db = client.db(dbName);
+    const students = await db.collection('students').find({}).toArray();
 
-  const clientRuns = await db
-    .collection('slc_runs')
-    .find({
-      status: 'committed',
-      'clientMeta.clientType': { $in: ['mobile', 'browser-extension', 'cli'] },
-    })
-    .project({ userId: 1, sourceId: 1 })
-    .toArray();
+    let studentsScanned = 0;
+    let sourcesWithCredentials = 0;
+    let sourcesUpdated = 0;
 
-  const eligible = new Set(
-    clientRuns.map((r) => `${String(r['userId'])}::${String(r['sourceId'])}`)
-  );
+    for (const student of students) {
+      studentsScanned += 1;
+      const sources = (student['dataSources'] as Array<Record<string, unknown>> | undefined) ?? [];
+      const unsetOps: Record<string, string> = {};
 
-  const students = await db.collection('students').find({}).toArray();
-  let scanned = 0;
-  let wouldPurge = 0;
+      for (let i = 0; i < sources.length; i++) {
+        const src = sources[i]!;
+        const provider = String(src['provider'] ?? '');
+        if (!PURGE_PROVIDERS.has(provider)) continue;
 
-  for (const student of students) {
-    const sources = (student['dataSources'] as Array<Record<string, unknown>> | undefined) ?? [];
-    for (let i = 0; i < sources.length; i++) {
-      const src = sources[i]!;
-      const provider = String(src['provider'] ?? '');
-      if (!PORTAL_PROVIDERS.has(provider)) continue;
-      scanned += 1;
-      const sourceId = String(src['id'] ?? src['sourceId'] ?? '');
-      const userId = String(student['userId'] ?? student['ownerId'] ?? '');
-      const key = `${userId}::${sourceId}`;
-      if (!eligible.has(key)) continue;
+        const creds = src['credentials'] as Record<string, unknown> | undefined;
+        if (!creds || Object.keys(creds).length === 0) continue;
 
-      const creds = src['credentials'] as Record<string, unknown> | undefined;
-      if (!creds || (!creds['password'] && !creds['username'])) continue;
+        // Credential blob present — queue for removal.
+        sourcesWithCredentials += 1;
+        unsetOps[`dataSources.${i}.credentials`] = '';
+      }
 
-      wouldPurge += 1;
+      if (Object.keys(unsetOps).length === 0) continue;
+
+      sourcesUpdated += Object.keys(unsetOps).length;
       if (apply) {
-        await db.collection('students').updateOne(
-          { _id: student._id },
-          {
-            $unset: {
-              [`dataSources.${i}.credentials.password`]: '',
-              [`dataSources.${i}.credentials.username`]: '',
-            },
-          }
-        );
+        await db.collection('students').updateOne({ _id: student._id }, { $unset: unsetOps });
       }
     }
-  }
 
-  console.log(
-    JSON.stringify({
-      mode: apply ? 'apply' : 'dry-run',
-      portalSourcesScanned: scanned,
-      sourcesEligibleForPurge: wouldPurge,
-    })
-  );
-  await client.close();
+    console.log(
+      JSON.stringify({
+        mode: apply ? 'apply' : 'dry-run',
+        studentsScanned,
+        sourcesWithCredentials,
+        sourcesUpdated: apply ? sourcesUpdated : 0,
+        wouldUpdate: !apply ? sourcesUpdated : undefined,
+        providers: [...PURGE_PROVIDERS].join(', '),
+      })
+    );
+  } finally {
+    await client.close();
+  }
 }
 
 main().catch((err) => {

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -30,10 +30,20 @@ import {
   RefreshTokenRepository,
   SessionRepository,
   StudentRepository,
+  SourceInviteRepository,
 } from '@scholaracle/database';
 import { SendGridPasswordResetEmailSender } from './services/PasswordResetEmailSender';
 import { SendGridInviteEmailSender } from './services/InviteEmailSender';
 import { SendGridPasswordChangedEmailSender } from './services/PasswordChangedEmailSender';
+import { SendGridSourceInviteEmailSender } from './services/source-invite/SourceInviteEmailSender';
+import { SourceInviteService } from './services/source-invite/SourceInviteService';
+import { StudentRepositoryOwnerLookup } from './services/source-invite/studentOwnerLookup';
+import { SystemClock } from './services/source-invite/clock';
+import { CryptoTokenGenerator, Sha256TokenHasher } from './services/source-invite/tokens';
+import { InstallLandingRenderer } from './services/source-invite/InstallLandingRenderer';
+import { installSourceRouter, sourceInvitesRouter } from './routes/source-invites/source-invites';
+import { MemoryRateLimiter } from './middleware/rateLimit';
+import { resolveApiBaseUrl } from './routes/students/attachmentSigning';
 import { adminAuthRouter } from './routes/admin/auth';
 import { customersRouter } from './routes/admin/customers/customers';
 import { analyticsRouter } from './routes/admin/analytics';
@@ -501,6 +511,31 @@ export function createApp(config: IServerConfig = {}, database?: Db): Express {
     app.use('/api/agenda', agendaRouter({ database, notificationService }));
     // SLC ingestion (device auth is public; approval uses user JWT; ingestion uses connector JWT)
     app.use('/api/ingest/v1', ingestV1Router({ database, jwtSecret, queue: notificationQueue }));
+
+    const sourceInviteStore = new SourceInviteRepository(database);
+    const sourceInviteService = new SourceInviteService(
+      sourceInviteStore,
+      new SystemClock(),
+      new CryptoTokenGenerator(),
+      new Sha256TokenHasher(),
+      new StudentRepositoryOwnerLookup(new StudentRepository(database))
+    );
+    const sourceInviteMailer = new SendGridSourceInviteEmailSender(sendGridConfig, sendGrid);
+    const sourceInviteConfig = {
+      issuer: sourceInviteService,
+      redeemer: sourceInviteService,
+      mailer: sourceInviteMailer,
+      landing: new InstallLandingRenderer(),
+      apiPublicOrigin: resolveApiBaseUrl(baseUrl) || baseUrl,
+      webOrigin: baseUrl,
+      limiter: new MemoryRateLimiter(),
+    };
+    app.use(
+      '/api/source-invites',
+      authMiddleware(authService),
+      sourceInvitesRouter(sourceInviteConfig)
+    );
+    app.use('/install-source', installSourceRouter(sourceInviteConfig));
 
     // Asset upload (connector auth) — mount under ingest path. ASSET_STORE=local|s3; S3 uses Railway Buckets or R2/B2.
     const assetStore = createAssetStore();

--- a/packages/api/src/services/scraper-generator/crawler.ts
+++ b/packages/api/src/services/scraper-generator/crawler.ts
@@ -1,6 +1,13 @@
 /**
- * Server-side crawler for scraper generation.
- * Pipeline: connect (HTTP HEAD) → crawl (Playwright login page) → authenticate check (CAPTCHA/MFA detection).
+ * Scraper generation pipeline utilities.
+ *
+ * NOTE: The `crawlStep` and `authenticateCheckStep` functions that previously
+ * launched a Playwright browser on the API server have been removed. Server-side
+ * Chromium against school portals is no longer permitted. Scraper generation
+ * based on live crawl is a local CLI concern only.
+ *
+ * The `connectStep` (HTTP HEAD reachability check) is retained as it makes no
+ * authenticated request and opens no browser.
  */
 
 export interface IConnectResult {
@@ -51,10 +58,10 @@ export interface IPageAnalysis {
 }
 
 const CONNECT_TIMEOUT_MS = 15_000;
-const CRAWL_TIMEOUT_MS = 30_000;
 
 /**
  * Step 1: Verify site is reachable (DNS + HTTP HEAD).
+ * This is a plain HTTP request — no browser launched.
  */
 export async function connectStep(loginUrl: string): Promise<IConnectResult> {
   const start = Date.now();
@@ -110,251 +117,33 @@ export async function connectStep(loginUrl: string): Promise<IConnectResult> {
 }
 
 /**
- * Step 2: Visit login page with Playwright, capture DOM and form structure.
+ * Browser crawl is not available on the server.
+ * Scraper generation via live page capture runs locally via the CLI.
  */
-export async function crawlStep(loginUrl: string): Promise<ICrawlResult> {
-  let browser: import('playwright').Browser | undefined;
-  try {
-    const { chromium } = await import('playwright');
-    browser = await chromium.launch({ headless: true });
-    const context = await browser.newContext({
-      userAgent: 'ScholaracleScraperGenerator/1.0',
-      ignoreHTTPSErrors: false,
-    });
-    const page = await context.newPage();
-    page.setDefaultTimeout(CRAWL_TIMEOUT_MS);
-
-    await page.goto(loginUrl, { waitUntil: 'domcontentloaded', timeout: CRAWL_TIMEOUT_MS });
-
-    const analysis = await page.evaluate(() => {
-      const result: {
-        title: string;
-        loginForm?: {
-          emailField?: string;
-          passwordField?: string;
-          submitButton?: string;
-          ssoOptions?: string[];
-          formAction?: string;
-          method?: string;
-        };
-        navigation: Array<{ text: string; href: string }>;
-        detectedFramework?: string;
-        pageHtml: string;
-      } = {
-        title: document.title || '',
-        navigation: [],
-        pageHtml: document.documentElement.outerHTML.slice(0, 50_000),
-      };
-
-      const forms = Array.from(document.querySelectorAll('form'));
-      for (const form of forms) {
-        const inputs = Array.from(form.querySelectorAll('input'));
-        let hasPassword = false;
-        let emailSelector = '';
-        let passwordSelector = '';
-        let submitSelector = '';
-        const ssoOptions: string[] = [];
-
-        for (const input of inputs) {
-          const type = (input.getAttribute('type') || 'text').toLowerCase();
-          const name = input.getAttribute('name') || input.id || '';
-          const sel = input.id ? `#${input.id}` : name ? `input[name="${name}"]` : '';
-          if (type === 'password') {
-            hasPassword = true;
-            passwordSelector = sel || 'input[type="password"]';
-          } else if (
-            type === 'email' ||
-            name.toLowerCase().includes('email') ||
-            name.toLowerCase().includes('user')
-          ) {
-            emailSelector = sel || 'input[type="email"]';
-          }
-        }
-        const submit = form.querySelector(
-          'button[type="submit"], input[type="submit"], button:not([type])'
-        );
-        if (submit) {
-          submitSelector = submit.id
-            ? `#${submit.id}`
-            : submit.tagName.toLowerCase() +
-              (submit.className ? `.${String(submit.className).trim().split(/\s+/)[0]}` : '');
-        }
-        const links = Array.from(form.querySelectorAll('a[href]'));
-        for (const a of links) {
-          const text = (a.textContent || '').trim();
-          if (/google|clever|microsoft|sso|sign in with|oauth/i.test(text)) {
-            ssoOptions.push(text.slice(0, 50));
-          }
-        }
-        if (hasPassword && (emailSelector || passwordSelector)) {
-          result.loginForm = {
-            emailField:
-              emailSelector || 'input[type="email"], input[name="username"], input[name="email"]',
-            passwordField: passwordSelector || 'input[type="password"]',
-            submitButton: submitSelector || 'button[type="submit"], input[type="submit"]',
-            ssoOptions: ssoOptions.length ? ssoOptions : undefined,
-            formAction: (form.getAttribute('action') || '').slice(0, 500),
-            method: (form.getAttribute('method') || 'get').toLowerCase(),
-          };
-          break;
-        }
-      }
-
-      const navSelectors = ['nav a', 'header a', '[role="navigation"] a', '.nav a', '.menu a'];
-      const seen = new Set<string>();
-      for (const sel of navSelectors) {
-        const links = Array.from(document.querySelectorAll(sel));
-        for (const a of links) {
-          const href = (a.getAttribute('href') || '').trim();
-          const text = (a.textContent || '').trim().slice(0, 80);
-          if (href && text && !seen.has(href)) {
-            seen.add(href);
-            result.navigation.push({ text, href });
-          }
-        }
-      }
-
-      if (document.querySelector('[data-reactroot], [data-reactid], #__next]'))
-        result.detectedFramework = 'react';
-      else if (document.querySelector('[ng-version], [ng-app]'))
-        result.detectedFramework = 'angular';
-      else if (document.querySelector('[data-v-]')) result.detectedFramework = 'vue';
-
-      return result;
-    });
-
-    await browser.close();
-    browser = undefined;
-
-    if (!analysis.loginForm) {
-      return {
-        ok: false,
-        title: analysis.title,
-        navigation: analysis.navigation,
-        detectedFramework: analysis.detectedFramework,
-        error: 'Could not find a login form at this URL',
-      };
-    }
-
-    return {
-      ok: true,
-      title: analysis.title,
-      loginForm: analysis.loginForm,
-      navigation: analysis.navigation,
-      detectedFramework: analysis.detectedFramework,
-      pageHtml: analysis.pageHtml,
-    };
-  } catch (err) {
-    if (browser) await browser.close().catch(() => {});
-    const msg = err instanceof Error ? err.message : String(err);
-    return {
-      ok: false,
-      error: msg.includes('timeout') ? 'Page load timed out' : msg.slice(0, 300),
-    };
-  }
+export async function crawlStep(_loginUrl: string): Promise<ICrawlResult> {
+  return {
+    ok: false,
+    error:
+      'Browser crawl is not available on the server. Use the local CLI to generate scrapers: `npx scholaracle-scraper generate --url <loginUrl>`.',
+  };
 }
 
-const CAPTCHA_SELECTORS = [
-  'iframe[src*="recaptcha"]',
-  'iframe[src*="hcaptcha"]',
-  '[data-sitekey]',
-  '.g-recaptcha',
-  '#recaptcha',
-  '[class*="captcha"]',
-];
-const MFA_SELECTORS = [
-  'input[name*="code"]',
-  'input[name*="otp"]',
-  'input[name*="verification"]',
-  '[class*="mfa"]',
-  '[class*="two-factor"]',
-  '[class*="2fa"]',
-  'input[type="tel"][maxlength="6"]',
-];
-
 /**
- * Step 3: Verify login form is automatable (no CAPTCHA, no MFA blocking).
+ * Browser auth check is not available on the server.
  */
 export async function authenticateCheckStep(
-  loginUrl: string,
-  crawlResult: ICrawlResult
+  _loginUrl: string,
+  _crawlResult: ICrawlResult
 ): Promise<IAuthenticateCheckResult> {
-  if (!crawlResult.ok || !crawlResult.loginForm) {
-    return { ok: false, error: crawlResult.error ?? 'Crawl did not find a login form' };
-  }
-  let browser: import('playwright').Browser | undefined;
-  try {
-    const { chromium } = await import('playwright');
-    browser = await chromium.launch({ headless: true });
-    const context = await browser.newContext({ userAgent: 'ScholaracleScraperGenerator/1.0' });
-    const page = await context.newPage();
-    page.setDefaultTimeout(15_000);
-    await page.goto(loginUrl, { waitUntil: 'domcontentloaded', timeout: 15_000 });
-
-    const check = await page.evaluate(
-      ({ captchaSel, mfaSel }: { captchaSel: string[]; mfaSel: string[] }) => {
-        let captchaDetected = false;
-        for (const sel of captchaSel) {
-          if (document.querySelector(sel)) {
-            captchaDetected = true;
-            break;
-          }
-        }
-        let mfaRequired = false;
-        for (const sel of mfaSel) {
-          const el = document.querySelector(sel);
-          if (el && (el as HTMLElement).offsetParent !== null) {
-            mfaRequired = true;
-            break;
-          }
-        }
-        return { captchaDetected, mfaRequired };
-      },
-      { captchaSel: CAPTCHA_SELECTORS, mfaSel: MFA_SELECTORS }
-    );
-
-    await browser.close();
-    browser = undefined;
-
-    if (check.captchaDetected) {
-      return {
-        ok: false,
-        loginFormUsable: true,
-        captchaDetected: true,
-        mfaRequired: false,
-        error: 'Login requires CAPTCHA — cannot be automated',
-      };
-    }
-    if (check.mfaRequired) {
-      return {
-        ok: false,
-        loginFormUsable: true,
-        captchaDetected: false,
-        mfaRequired: true,
-        error: 'Login requires multi-factor authentication',
-      };
-    }
-
-    return {
-      ok: true,
-      loginFormUsable: true,
-      captchaDetected: false,
-      mfaRequired: false,
-      loginMethod: 'email_password',
-      ssoAvailable: crawlResult.loginForm.ssoOptions,
-    };
-  } catch (err) {
-    if (browser) await browser.close().catch(() => {});
-    return {
-      ok: false,
-      error: err instanceof Error ? err.message : String(err),
-    };
-  }
+  return {
+    ok: false,
+    error: 'Browser crawl is not available on the server. Use the local CLI to generate scrapers.',
+  };
 }
 
 /**
  * Full pipeline: connect → crawl → authenticate check.
- * Returns page analysis for AI or throws with user-facing error.
+ * Crawl and auth check are not available on the server.
  */
 export async function runCrawlPipeline(loginUrl: string): Promise<IPageAnalysis> {
   const connect = await connectStep(loginUrl);
@@ -362,22 +151,7 @@ export async function runCrawlPipeline(loginUrl: string): Promise<IPageAnalysis>
     throw new Error(connect.error ?? 'Could not connect to the site');
   }
 
-  const crawl = await crawlStep(loginUrl);
-  if (!crawl.ok) {
-    throw new Error(crawl.error ?? 'Could not find a login form at this URL');
-  }
-
-  const auth = await authenticateCheckStep(loginUrl, crawl);
-  if (!auth.ok) {
-    throw new Error(auth.error ?? 'Login cannot be automated');
-  }
-
-  return {
-    url: loginUrl,
-    title: crawl.title ?? '',
-    loginForm: crawl.loginForm!,
-    navigation: crawl.navigation ?? [],
-    detectedFramework: crawl.detectedFramework,
-    pageHtml: crawl.pageHtml,
-  };
+  throw new Error(
+    'Browser crawl is not available on the server. Use the local CLI to generate scrapers: `npx scholaracle-scraper generate --url <loginUrl>`.'
+  );
 }

--- a/packages/api/src/services/source-invite/InstallLandingRenderer.ts
+++ b/packages/api/src/services/source-invite/InstallLandingRenderer.ts
@@ -1,0 +1,39 @@
+import { sanitizeInstallToken } from '@scholaracle/contracts';
+
+export interface IInstallLandingRenderer {
+  render(params: { readonly tokenHex: string; readonly webOrigin: string }): string;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+}
+
+function stripSlash(origin: string): string {
+  return origin.replace(/\/+$/, '');
+}
+
+/**
+ * Stateless landing HTML (SOURCE_INVITE.md §6). Does not look up the token.
+ */
+export class InstallLandingRenderer implements IInstallLandingRenderer {
+  render(params: { readonly tokenHex: string; readonly webOrigin: string }): string {
+    const token = sanitizeInstallToken(params.tokenHex);
+    const qs = token ? `?t=${encodeURIComponent(token)}` : '';
+    const appHref = escapeHtml(`scholarmancy://install-source${qs}`);
+    const webHref = escapeHtml(`${stripSlash(params.webOrigin)}/dashboard/install-source${qs}`);
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Install a school portal — Scholarmancy</title>
+</head>
+<body>
+  <h1>Install a school portal in Scholarmancy</h1>
+  <p>Open Scholarmancy, then tap the link again if needed.</p>
+  <p><a href="${appHref}" data-testid="open-app">Open in Scholarmancy</a></p>
+  <p><a href="${webHref}" data-testid="continue-browser">Continue in browser</a></p>
+</body>
+</html>`;
+  }
+}

--- a/packages/api/src/services/source-invite/SourceInviteEmailSender.test.ts
+++ b/packages/api/src/services/source-invite/SourceInviteEmailSender.test.ts
@@ -1,0 +1,48 @@
+/**
+ * SOURCE_INVITE.md §7
+ */
+
+import type { MailService } from '@sendgrid/mail';
+import { SendGridSourceInviteEmailSender } from './SourceInviteEmailSender';
+
+describe('SendGridSourceInviteEmailSender', () => {
+  const landingUrl = `https://api.example.com/install-source?t=${'ab'.repeat(32)}`;
+
+  it('empty apiKey no-ops', async () => {
+    const send = jest.fn();
+    const sender = new SendGridSourceInviteEmailSender(
+      { apiKey: '', fromEmail: 'noreply@example.com', fromName: 'Scholarmancy' },
+      { send, setApiKey: jest.fn() } as unknown as MailService
+    );
+    await sender.sendInstallLink({
+      to: 'parent@example.com',
+      providerName: 'Skyward Family Access',
+      studentName: 'Ava Lewis',
+      landingUrl,
+      expiresAt: new Date('2026-08-22T00:00:00.000Z'),
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('send uses branded html, Skyward subject, landing URL, no password', async () => {
+    const send = jest.fn().mockResolvedValue([{}]);
+    const sender = new SendGridSourceInviteEmailSender(
+      { apiKey: 'SG.test', fromEmail: 'noreply@example.com', fromName: 'Scholarmancy' },
+      { send, setApiKey: jest.fn() } as unknown as MailService
+    );
+    await sender.sendInstallLink({
+      to: 'parent@example.com',
+      providerName: 'Skyward Family Access',
+      studentName: 'Ava Lewis',
+      landingUrl,
+      expiresAt: new Date('2026-08-22T00:00:00.000Z'),
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    const msg = send.mock.calls[0]?.[0] as { subject: string; html: string; text: string };
+    expect(msg.subject).toContain('Skyward');
+    expect(msg.html).toContain(landingUrl);
+    expect(msg.text).toContain(landingUrl);
+    expect(msg.html.toLowerCase()).not.toContain('password=');
+    expect(msg.html).not.toContain('skyward.iscorp.com');
+  });
+});

--- a/packages/api/src/services/source-invite/SourceInviteEmailSender.ts
+++ b/packages/api/src/services/source-invite/SourceInviteEmailSender.ts
@@ -1,0 +1,75 @@
+import type { MailService } from '@sendgrid/mail';
+import { buildBrandedEmail } from '../emailTemplate';
+
+export interface ISourceInviteMailerConfig {
+  readonly apiKey: string;
+  readonly fromEmail: string;
+  readonly fromName: string;
+}
+
+export interface ISourceInviteMailer {
+  sendInstallLink(params: {
+    readonly to: string;
+    readonly providerName: string;
+    readonly studentName: string;
+    readonly landingUrl: string;
+    readonly expiresAt: Date;
+  }): Promise<void>;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function firstName(fullName: string): string {
+  const part = fullName.trim().split(/\s+/)[0];
+  return part && part.length > 0 ? part : 'there';
+}
+
+/**
+ * SOURCE_INVITE.md §7. Empty apiKey no-ops.
+ */
+export class SendGridSourceInviteEmailSender implements ISourceInviteMailer {
+  constructor(
+    private readonly _config: ISourceInviteMailerConfig,
+    private readonly _sendGrid: MailService
+  ) {
+    if (_config.apiKey) {
+      this._sendGrid.setApiKey(_config.apiKey);
+    }
+  }
+
+  async sendInstallLink(params: {
+    readonly to: string;
+    readonly providerName: string;
+    readonly studentName: string;
+    readonly landingUrl: string;
+    readonly expiresAt: Date;
+  }): Promise<void> {
+    if (!this._config.apiKey) return;
+    const subject = `Install ${params.providerName} in Scholarmancy`;
+    const name = escapeHtml(firstName(params.studentName));
+    const provider = escapeHtml(params.providerName);
+    const link = escapeHtml(params.landingUrl);
+    const when = params.expiresAt.toUTCString();
+    const bodyHtml = `
+      <p>Hi ${name},</p>
+      <p>Tap the link below on your phone or computer to add <strong>${provider}</strong> for this student in Scholarmancy.</p>
+      <p><a href="${link}">Open install link</a></p>
+      <p>This link expires ${escapeHtml(when)}.</p>
+      <p>This message never includes your school password. You will type it in the app or browser after the source is registered.</p>
+    `.trim();
+    const html = buildBrandedEmail({ title: subject, bodyHtml });
+    await this._sendGrid.send({
+      to: params.to,
+      from: { email: this._config.fromEmail, name: this._config.fromName },
+      subject,
+      text: `Install ${params.providerName} in Scholarmancy: ${params.landingUrl}. This message never includes your school password.`,
+      html,
+    });
+  }
+}

--- a/packages/api/src/services/source-invite/SourceInviteService.test.ts
+++ b/packages/api/src/services/source-invite/SourceInviteService.test.ts
@@ -1,0 +1,286 @@
+/**
+ * SOURCE_INVITE.md §4.3 / §5.4
+ */
+
+import { ObjectId } from 'mongodb';
+import {
+  SOURCE_INVITE_ADAPTER_IDS,
+  SOURCE_INVITE_REDEEM_ERROR,
+  SOURCE_INVITE_TOKEN_BYTES,
+  SOURCE_INVITE_TTL_MS,
+  assertNoSecrets,
+} from '@scholaracle/contracts';
+import type { ISourceInviteRecord, ISourceInviteStore } from '@scholaracle/database';
+import { FakeClock } from './clock';
+import { SourceInviteService } from './SourceInviteService';
+import type { IOwnedStudent, IStudentOwnerLookup } from './studentOwnerLookup';
+import { FixedTokenGenerator, Sha256TokenHasher } from './tokens';
+
+const AVA_TOKEN = 'ab'.repeat(32);
+const USER_A = new ObjectId().toString();
+const USER_B = new ObjectId().toString();
+const STUDENT_ID = new ObjectId().toString();
+
+class MemorySourceInviteStore implements ISourceInviteStore {
+  readonly rows: ISourceInviteRecord[] = [];
+
+  async insert(record: Omit<ISourceInviteRecord, 'id'>): Promise<ISourceInviteRecord> {
+    const saved: ISourceInviteRecord = { ...record, id: `id-${this.rows.length + 1}` };
+    this.rows.push(saved);
+    return saved;
+  }
+
+  async findByHash(tokenHash: string): Promise<ISourceInviteRecord | null> {
+    return this.rows.find((r) => r.tokenHash === tokenHash) ?? null;
+  }
+
+  async consumeIfOpen(id: string, now: Date): Promise<boolean> {
+    const row = this.rows.find((r) => r.id === id);
+    if (!row || row.consumedAt !== null || row.expiresAt.getTime() <= now.getTime()) return false;
+    const idx = this.rows.indexOf(row);
+    this.rows[idx] = { ...row, consumedAt: now };
+    return true;
+  }
+
+  async invalidateOpen(params: {
+    readonly userId: string;
+    readonly studentId: string;
+    readonly provider: string;
+    readonly institutionExternalId: string;
+    readonly now: Date;
+  }): Promise<number> {
+    let n = 0;
+    for (let i = 0; i < this.rows.length; i += 1) {
+      const row = this.rows[i];
+      if (!row || row.consumedAt !== null) continue;
+      if (
+        row.userId === params.userId &&
+        row.payload.studentId === params.studentId &&
+        row.payload.provider === params.provider &&
+        row.payload.institutionExternalId === params.institutionExternalId
+      ) {
+        this.rows[i] = { ...row, consumedAt: params.now };
+        n += 1;
+      }
+    }
+    return n;
+  }
+}
+
+class FakeStudents implements IStudentOwnerLookup {
+  constructor(private readonly owned: IOwnedStudent | null) {}
+
+  async findOwnedStudent(_userId: string, studentId: string): Promise<IOwnedStudent | null> {
+    if (!this.owned) return null;
+    return this.owned.id === studentId ? this.owned : null;
+  }
+}
+
+function makeService(
+  store: MemorySourceInviteStore,
+  clock: FakeClock,
+  students: IStudentOwnerLookup = new FakeStudents({
+    id: STUDENT_ID,
+    name: 'Ava Lewis',
+    studentExternalId: 'ava-lewis',
+  })
+): SourceInviteService {
+  return new SourceInviteService(
+    store,
+    clock,
+    new FixedTokenGenerator(AVA_TOKEN),
+    new Sha256TokenHasher(),
+    students
+  );
+}
+
+describe('SourceInviteService', () => {
+  const hasher = new Sha256TokenHasher();
+
+  it('issue then redeem same user returns Ava payload', async () => {
+    const store = new MemorySourceInviteStore();
+    const clock = new FakeClock(new Date('2026-08-15T00:00:00.000Z'));
+    const service = makeService(store, clock);
+    const issued = await service.issue({
+      userId: USER_A,
+      request: {
+        studentId: STUDENT_ID,
+        provider: 'skyward',
+        portalBaseUrl: 'https://skyward.iscorp.com/',
+      },
+    });
+    expect(issued.token).toBe(AVA_TOKEN);
+    expect(issued.payload.portalBaseUrl).toBe('https://skyward.iscorp.com');
+    expect(issued.payload.adapterId).toBe(SOURCE_INVITE_ADAPTER_IDS.skyward);
+    expect(issued.payload.studentExternalId).toBe('ava-lewis');
+    expect(issued.expiresAt.getTime() - clock.now().getTime()).toBe(SOURCE_INVITE_TTL_MS);
+
+    const payload = await service.redeem({ userId: USER_A, token: AVA_TOKEN });
+    expect(payload).toEqual(issued.payload);
+  });
+
+  it('second redeem fails with typed not-found', async () => {
+    const store = new MemorySourceInviteStore();
+    const clock = new FakeClock(new Date('2026-08-15T00:00:00.000Z'));
+    const service = makeService(store, clock);
+    await service.issue({
+      userId: USER_A,
+      request: {
+        studentId: STUDENT_ID,
+        provider: 'skyward',
+        portalBaseUrl: 'https://skyward.iscorp.com',
+      },
+    });
+    await service.redeem({ userId: USER_A, token: AVA_TOKEN });
+    await expect(service.redeem({ userId: USER_A, token: AVA_TOKEN })).rejects.toThrow(
+      SOURCE_INVITE_REDEEM_ERROR
+    );
+  });
+
+  it('wrong userId fails with the same not-found message', async () => {
+    const store = new MemorySourceInviteStore();
+    const clock = new FakeClock(new Date('2026-08-15T00:00:00.000Z'));
+    const service = makeService(store, clock);
+    await service.issue({
+      userId: USER_A,
+      request: {
+        studentId: STUDENT_ID,
+        provider: 'skyward',
+        portalBaseUrl: 'https://skyward.iscorp.com',
+      },
+    });
+    await expect(service.redeem({ userId: USER_B, token: AVA_TOKEN })).rejects.toThrow(
+      SOURCE_INVITE_REDEEM_ERROR
+    );
+  });
+
+  it('FakeClock + 8 days → redeem fails', async () => {
+    const store = new MemorySourceInviteStore();
+    const clock = new FakeClock(new Date('2026-08-15T00:00:00.000Z'));
+    const service = makeService(store, clock);
+    await service.issue({
+      userId: USER_A,
+      request: {
+        studentId: STUDENT_ID,
+        provider: 'skyward',
+        portalBaseUrl: 'https://skyward.iscorp.com',
+      },
+    });
+    clock.advance(8 * 24 * 60 * 60 * 1000);
+    await expect(service.redeem({ userId: USER_A, token: AVA_TOKEN })).rejects.toThrow(
+      SOURCE_INVITE_REDEEM_ERROR
+    );
+  });
+
+  it('re-issue invalidates previous token', async () => {
+    const store = new MemorySourceInviteStore();
+    const clock = new FakeClock(new Date('2026-08-15T00:00:00.000Z'));
+    const first = new SourceInviteService(
+      store,
+      clock,
+      new FixedTokenGenerator('aa'.repeat(32)),
+      hasher,
+      new FakeStudents({ id: STUDENT_ID, name: 'Ava Lewis', studentExternalId: 'ava-lewis' })
+    );
+    await first.issue({
+      userId: USER_A,
+      request: {
+        studentId: STUDENT_ID,
+        provider: 'skyward',
+        portalBaseUrl: 'https://skyward.iscorp.com',
+      },
+    });
+    const second = new SourceInviteService(
+      store,
+      clock,
+      new FixedTokenGenerator('bb'.repeat(32)),
+      hasher,
+      new FakeStudents({ id: STUDENT_ID, name: 'Ava Lewis', studentExternalId: 'ava-lewis' })
+    );
+    await second.issue({
+      userId: USER_A,
+      request: {
+        studentId: STUDENT_ID,
+        provider: 'skyward',
+        portalBaseUrl: 'https://skyward.iscorp.com',
+      },
+    });
+    await expect(first.redeem({ userId: USER_A, token: 'aa'.repeat(32) })).rejects.toThrow(
+      SOURCE_INVITE_REDEEM_ERROR
+    );
+    await expect(second.redeem({ userId: USER_A, token: 'bb'.repeat(32) })).resolves.toMatchObject({
+      provider: 'skyward',
+    });
+  });
+
+  it('issue for other user’s studentId → not found', async () => {
+    const store = new MemorySourceInviteStore();
+    const clock = new FakeClock(new Date('2026-08-15T00:00:00.000Z'));
+    const service = makeService(store, clock, new FakeStudents(null));
+    await expect(
+      service.issue({
+        userId: USER_A,
+        request: {
+          studentId: STUDENT_ID,
+          provider: 'skyward',
+          portalBaseUrl: 'https://skyward.iscorp.com',
+        },
+      })
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it('stored record JSON assertNoSecrets on payload; hash equals hasher.hash(raw)', async () => {
+    const store = new MemorySourceInviteStore();
+    const clock = new FakeClock(new Date('2026-08-15T00:00:00.000Z'));
+    const service = makeService(store, clock);
+    await service.issue({
+      userId: USER_A,
+      request: {
+        studentId: STUDENT_ID,
+        provider: 'skyward',
+        portalBaseUrl: 'https://skyward.iscorp.com',
+      },
+    });
+    const row = store.rows[0];
+    expect(row).toBeDefined();
+    expect(row?.tokenHash).toBe(hasher.hash(AVA_TOKEN));
+    expect(() => assertNoSecrets(row?.payload)).not.toThrow();
+    expect(JSON.stringify(row)).not.toContain('"token":');
+  });
+
+  it('ITokenGenerator is used with 32 bytes', async () => {
+    const store = new MemorySourceInviteStore();
+    const clock = new FakeClock(new Date('2026-08-15T00:00:00.000Z'));
+    let nbytesSeen = 0;
+    const service = new SourceInviteService(
+      store,
+      clock,
+      {
+        randomHex(nbytes: number): string {
+          nbytesSeen = nbytes;
+          return AVA_TOKEN;
+        },
+      },
+      hasher,
+      new FakeStudents({ id: STUDENT_ID, name: 'Ava', studentExternalId: 'ava-lewis' })
+    );
+    await service.issue({
+      userId: USER_A,
+      request: {
+        studentId: STUDENT_ID,
+        provider: 'skyward',
+        portalBaseUrl: 'https://skyward.iscorp.com',
+      },
+    });
+    expect(nbytesSeen).toBe(SOURCE_INVITE_TOKEN_BYTES);
+  });
+
+  it('redeem of short token fails closed', async () => {
+    const store = new MemorySourceInviteStore();
+    const clock = new FakeClock(new Date('2026-08-15T00:00:00.000Z'));
+    const service = makeService(store, clock);
+    await expect(service.redeem({ userId: USER_A, token: 'short' })).rejects.toThrow(
+      SOURCE_INVITE_REDEEM_ERROR
+    );
+  });
+});

--- a/packages/api/src/services/source-invite/SourceInviteService.ts
+++ b/packages/api/src/services/source-invite/SourceInviteService.ts
@@ -1,0 +1,134 @@
+/**
+ * SOURCE_INVITE.md §4.3 — issue + redeem. Callers inject the small interface they need.
+ */
+
+import {
+  NotFoundError,
+  SOURCE_INVITE_ADAPTER_IDS,
+  SOURCE_INVITE_PROVIDER_NAMES,
+  SOURCE_INVITE_REDEEM_ERROR,
+  SOURCE_INVITE_TOKEN_BYTES,
+  SOURCE_INVITE_TTL_MS,
+  ValidationError,
+  assertNoSecrets,
+  isSourceInviteProvider,
+  sanitizeInstallToken,
+  type ISourceInviteIssueRequest,
+  type ISourceInvitePayload,
+} from '@scholaracle/contracts';
+import type { ISourceInviteStore } from '@scholaracle/database';
+import type { IClock } from './clock';
+import { institutionExternalIdFromPortalUrl, normalizePortalUrl } from './normalizePortalUrl';
+import type { IStudentOwnerLookup } from './studentOwnerLookup';
+import type { ITokenGenerator, ITokenHasher } from './tokens';
+
+export interface IIssuedSourceInvite {
+  readonly token: string;
+  readonly expiresAt: Date;
+  readonly payload: ISourceInvitePayload;
+  readonly studentName: string;
+  readonly providerName: string;
+}
+
+export interface ISourceInviteIssuer {
+  issue(params: {
+    readonly userId: string;
+    readonly request: ISourceInviteIssueRequest;
+  }): Promise<IIssuedSourceInvite>;
+}
+
+export interface ISourceInviteRedeemer {
+  redeem(params: {
+    readonly userId: string;
+    readonly token: string;
+  }): Promise<ISourceInvitePayload>;
+}
+
+export class SourceInviteService implements ISourceInviteIssuer, ISourceInviteRedeemer {
+  constructor(
+    private readonly _store: ISourceInviteStore,
+    private readonly _clock: IClock,
+    private readonly _tokens: ITokenGenerator,
+    private readonly _hasher: ITokenHasher,
+    private readonly _students: IStudentOwnerLookup
+  ) {}
+
+  async issue(params: {
+    readonly userId: string;
+    readonly request: ISourceInviteIssueRequest;
+  }): Promise<IIssuedSourceInvite> {
+    assertNoSecrets(params.request);
+    if (!isSourceInviteProvider(params.request.provider)) {
+      throw new ValidationError('Unknown provider');
+    }
+    const portalBaseUrl = normalizePortalUrl(params.request.portalBaseUrl);
+    const institutionExternalId = institutionExternalIdFromPortalUrl(portalBaseUrl);
+    const student = await this._students.findOwnedStudent(params.userId, params.request.studentId);
+    if (!student) {
+      throw new NotFoundError('Not found');
+    }
+
+    const now = this._clock.now();
+    await this._store.invalidateOpen({
+      userId: params.userId,
+      studentId: student.id,
+      provider: params.request.provider,
+      institutionExternalId,
+      now,
+    });
+
+    const adapterId = SOURCE_INVITE_ADAPTER_IDS[params.request.provider];
+    const providerName = SOURCE_INVITE_PROVIDER_NAMES[params.request.provider];
+    const displayName =
+      params.request.displayName?.trim() || `${providerName} (${institutionExternalId})`;
+    const payload: ISourceInvitePayload = {
+      provider: params.request.provider,
+      adapterId,
+      portalBaseUrl,
+      displayName,
+      studentId: student.id,
+      studentExternalId: student.studentExternalId,
+      institutionExternalId,
+    };
+    assertNoSecrets(payload);
+
+    const token = this._tokens.randomHex(SOURCE_INVITE_TOKEN_BYTES);
+    const tokenHash = this._hasher.hash(token);
+    const expiresAt = new Date(now.getTime() + SOURCE_INVITE_TTL_MS);
+    await this._store.insert({
+      userId: params.userId,
+      tokenHash,
+      payload,
+      expiresAt,
+      createdAt: now,
+      consumedAt: null,
+    });
+
+    return { token, expiresAt, payload, studentName: student.name, providerName };
+  }
+
+  async redeem(params: {
+    readonly userId: string;
+    readonly token: string;
+  }): Promise<ISourceInvitePayload> {
+    const token = sanitizeInstallToken(params.token);
+    if (!token) {
+      throw new NotFoundError(SOURCE_INVITE_REDEEM_ERROR);
+    }
+    const record = await this._store.findByHash(this._hasher.hash(token));
+    const now = this._clock.now();
+    if (
+      !record ||
+      record.userId !== params.userId ||
+      record.consumedAt !== null ||
+      record.expiresAt.getTime() <= now.getTime()
+    ) {
+      throw new NotFoundError(SOURCE_INVITE_REDEEM_ERROR);
+    }
+    const consumed = await this._store.consumeIfOpen(record.id, now);
+    if (!consumed) {
+      throw new NotFoundError(SOURCE_INVITE_REDEEM_ERROR);
+    }
+    return record.payload;
+  }
+}

--- a/packages/api/src/services/source-invite/clock.ts
+++ b/packages/api/src/services/source-invite/clock.ts
@@ -1,0 +1,21 @@
+export interface IClock {
+  now(): Date;
+}
+
+export class SystemClock implements IClock {
+  now(): Date {
+    return new Date();
+  }
+}
+
+export class FakeClock implements IClock {
+  constructor(private _now: Date) {}
+
+  now(): Date {
+    return this._now;
+  }
+
+  advance(ms: number): void {
+    this._now = new Date(this._now.getTime() + ms);
+  }
+}

--- a/packages/api/src/services/source-invite/normalizePortalUrl.test.ts
+++ b/packages/api/src/services/source-invite/normalizePortalUrl.test.ts
@@ -1,0 +1,27 @@
+/**
+ * SOURCE_INVITE.md §5.2
+ */
+
+import { normalizePortalUrl } from './normalizePortalUrl';
+
+describe('normalizePortalUrl', () => {
+  it('strips trailing slash and lowercases host for Ava Skyward', () => {
+    expect(normalizePortalUrl('https://skyward.iscorp.com/')).toBe('https://skyward.iscorp.com');
+  });
+
+  it('rejects http', () => {
+    expect(() => normalizePortalUrl('http://skyward.iscorp.com')).toThrow(/https/i);
+  });
+
+  it('rejects userinfo credentials', () => {
+    expect(() => normalizePortalUrl('https://user:pass@skyward.iscorp.com')).toThrow(/credential/i);
+  });
+
+  it('rejects javascript URLs', () => {
+    expect(() => normalizePortalUrl('javascript:alert(1)')).toThrow();
+  });
+
+  it('rejects empty host', () => {
+    expect(() => normalizePortalUrl('https://')).toThrow();
+  });
+});

--- a/packages/api/src/services/source-invite/normalizePortalUrl.ts
+++ b/packages/api/src/services/source-invite/normalizePortalUrl.ts
@@ -1,0 +1,33 @@
+/**
+ * SOURCE_INVITE.md §5.2 — https portal URL normalize (Node URL API is OK here).
+ */
+
+import { ValidationError } from '@scholaracle/contracts';
+
+export function normalizePortalUrl(input: string): string {
+  const trimmed = input.trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new ValidationError('Enter a full portal address like https://school.example.com');
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new ValidationError('Portal URL must use https');
+  }
+  if (parsed.username !== '' || parsed.password !== '') {
+    throw new ValidationError('Portal URL must not include credentials');
+  }
+  if (parsed.hostname === '') {
+    throw new ValidationError('Enter a full portal address like https://school.example.com');
+  }
+  parsed.hostname = parsed.hostname.toLowerCase();
+  parsed.hash = '';
+  let href = parsed.href;
+  while (href.endsWith('/')) href = href.slice(0, -1);
+  return href;
+}
+
+export function institutionExternalIdFromPortalUrl(portalBaseUrl: string): string {
+  return new URL(portalBaseUrl).hostname.toLowerCase();
+}

--- a/packages/api/src/services/source-invite/studentOwnerLookup.ts
+++ b/packages/api/src/services/source-invite/studentOwnerLookup.ts
@@ -1,0 +1,29 @@
+import { ObjectId } from 'mongodb';
+import type { IStudentReader } from '@scholaracle/database';
+
+export interface IOwnedStudent {
+  readonly id: string;
+  readonly name: string;
+  readonly studentExternalId: string;
+}
+
+export interface IStudentOwnerLookup {
+  findOwnedStudent(userId: string, studentId: string): Promise<IOwnedStudent | null>;
+}
+
+export class StudentRepositoryOwnerLookup implements IStudentOwnerLookup {
+  constructor(private readonly _students: IStudentReader) {}
+
+  async findOwnedStudent(userId: string, studentId: string): Promise<IOwnedStudent | null> {
+    if (!ObjectId.isValid(studentId)) return null;
+    const student = await this._students.findById(studentId);
+    if (!student?._id) return null;
+    if (!student.hasAccess(userId)) return null;
+    const id = student._id.toString();
+    return {
+      id,
+      name: student.name,
+      studentExternalId: student.studentId && student.studentId.length > 0 ? student.studentId : id,
+    };
+  }
+}

--- a/packages/api/src/services/source-invite/tokens.ts
+++ b/packages/api/src/services/source-invite/tokens.ts
@@ -1,0 +1,33 @@
+import { randomBytes, createHash } from 'node:crypto';
+import { SOURCE_INVITE_TOKEN_BYTES } from '@scholaracle/contracts';
+
+export interface ITokenGenerator {
+  randomHex(nbytes: number): string;
+}
+
+export interface ITokenHasher {
+  hash(token: string): string;
+}
+
+export class CryptoTokenGenerator implements ITokenGenerator {
+  randomHex(nbytes: number = SOURCE_INVITE_TOKEN_BYTES): string {
+    return randomBytes(nbytes).toString('hex');
+  }
+}
+
+export class Sha256TokenHasher implements ITokenHasher {
+  hash(token: string): string {
+    return createHash('sha256').update(token, 'utf8').digest('hex');
+  }
+}
+
+export class FixedTokenGenerator implements ITokenGenerator {
+  constructor(private readonly hex: string) {}
+
+  randomHex(nbytes: number): string {
+    if (this.hex.length !== nbytes * 2) {
+      throw new Error(`Fixed token must be ${nbytes * 2} hex chars`);
+    }
+    return this.hex;
+  }
+}

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "../interfaces" },
     { "path": "../contracts" },
     { "path": "../agents" },
-    { "path": "../logger" }
+    { "path": "../logger" },
+    { "path": "../scraper-core" }
   ]
 }

--- a/packages/browser-extension/src/content/ContentScriptPageDriver.ts
+++ b/packages/browser-extension/src/content/ContentScriptPageDriver.ts
@@ -3,6 +3,19 @@
  *
  * Runs in the page context — no browser automation needed.
  * Uses document APIs directly and navigates via window.location.
+ *
+ * ## waitUntil semantics
+ * `goto()` waits for the `load` event. For SPAs that navigate without a full
+ * page reload (e.g. Skyward hash routing), callers should use
+ * `waitForUrlIncludes()` after goto instead of relying on load events.
+ *
+ * ## onNewPage / popup degradation
+ * `onNewPage` is a no-op here. Extension content scripts cannot intercept
+ * popup windows. Recipes that open popups (e.g. Skyward's gradeInfoDialog
+ * click) MUST degrade gracefully when the dialog doesn't appear in-page —
+ * `extractSkywardCourseAssignments` handles this by returning `[]` when
+ * `#gradeInfoDialog` is absent. Do NOT rely on `onNewPage` in extension
+ * context; that interface is only honoured by Playwright and mobile WebView.
  */
 
 import type { IPageDriver, IGotoOptions, IWaitOptions, BrowserFn } from '@scholaracle/scraper-core';
@@ -60,6 +73,7 @@ export class ContentScriptPageDriver implements IPageDriver {
   }
 
   onNewPage(_handler: (page: IPageDriver) => Promise<void>): void {
-    // Not applicable in content script context
+    // No-op: extension content scripts cannot intercept popup windows.
+    // See module-level JSDoc for degradation guidance.
   }
 }

--- a/packages/browser-extension/src/content/content-script.ts
+++ b/packages/browser-extension/src/content/content-script.ts
@@ -3,26 +3,17 @@
  *
  * Waits for a RUN_SYNC message from the service worker, then:
  *   1. Creates a ContentScriptPageDriver (operates on the current page)
- *   2. Runs the platform recipe via scraper-core
- *   3. Transforms, validates, and uploads the envelope
- *   4. Sends SYNC_COMPLETE or SYNC_FAILED back to the service worker
+ *   2. Calls runClientScrape (extract → transform → validate → upload)
+ *   3. Sends SYNC_COMPLETE or SYNC_FAILED back to the service worker
+ *
+ * Authentication (login) is NOT handled here — the service worker prompts the
+ * user to navigate to the portal login page before triggering RUN_SYNC.
  */
 
-import {
-  runCanvasRecipe,
-  runSkywardRecipe,
-  runAeriesRecipe,
-  transformCanvasExtract,
-  transformSkywardExtract,
-  transformAeriesExtract,
-  validateEnvelope,
-} from '@scholaracle/scraper-core';
-import { SLC_INGEST_SCHEMA_VERSION_V1, type ISlcIngestEnvelopeV1 } from '@scholaracle/contracts';
-import { uploadEnvelope } from '../lib/ingest';
+import { runClientScrape, SyncError } from '@scholaracle/scraper-core';
+import { ExtensionIngestUploader } from '../lib/ingest';
 import { ContentScriptPageDriver } from './ContentScriptPageDriver';
 import type { IPortalCredential } from '../lib/storage';
-
-const EXTENSION_VERSION = '0.1.0';
 
 interface IRunSyncMessage {
   readonly type: 'RUN_SYNC';
@@ -43,132 +34,59 @@ chrome.runtime.onMessage.addListener((message: unknown, _sender, _sendResponse) 
 });
 
 async function runSync(msg: IRunSyncMessage): Promise<void> {
-  const { runId, credential, connectorToken, apiBaseUrl } = msg;
+  const { credential, connectorToken, apiBaseUrl } = msg;
   const {
     provider,
     sourceId,
     adapterId,
-    baseUrl,
     adapterVersion,
+    baseUrl,
     studentExternalId,
     institutionExternalId,
   } = credential;
 
-  const ctx = { provider, adapterId, studentExternalId, institutionExternalId };
   const driver = new ContentScriptPageDriver();
-  let opCount = 0;
 
   try {
-    const now = new Date().toISOString();
-    let envelope: ISlcIngestEnvelopeV1;
-
-    if (provider === 'canvas') {
-      const raw = await runCanvasRecipe(driver, baseUrl);
-      const ops = transformCanvasExtract(raw, ctx);
-      opCount = ops.length;
-      envelope = buildEnvelope({
-        runId,
-        now,
+    const envelope = await runClientScrape({
+      driver,
+      config: {
         provider,
         adapterId,
         adapterVersion,
-        sourceId,
         baseUrl,
-        ops,
-      });
-    } else if (provider === 'skyward') {
-      const raw = await runSkywardRecipe(driver, baseUrl);
-      const ops = transformSkywardExtract(raw, ctx);
-      opCount = ops.length;
-      envelope = buildEnvelope({
-        runId,
-        now,
-        provider,
-        adapterId,
-        adapterVersion,
         sourceId,
-        baseUrl,
-        ops,
-      });
-    } else if (provider === 'aeries') {
-      const raw = await runAeriesRecipe(driver, baseUrl);
-      const ops = transformAeriesExtract(raw, ctx);
-      opCount = ops.length;
-      envelope = buildEnvelope({
-        runId,
-        now,
-        provider,
-        adapterId,
-        adapterVersion,
-        sourceId,
-        baseUrl,
-        ops,
-      });
-    } else {
-      throw new Error(`Unknown provider: ${provider}`);
-    }
-
-    const report = validateEnvelope(envelope);
-    if (!report.passed) throw new Error(`Validation failed: ${report.errorCount} errors`);
-
-    await uploadEnvelope(envelope, connectorToken, apiBaseUrl);
+        studentExternalId,
+        institutionExternalId,
+      },
+      clientType: 'browser-extension',
+      uploader: new ExtensionIngestUploader(apiBaseUrl, connectorToken),
+      onProgress: (p) =>
+        chrome.runtime.sendMessage({ type: 'SYNC_PROGRESS', phase: p.phase, message: p.message }),
+    });
 
     chrome.runtime.sendMessage({
       type: 'SYNC_COMPLETE',
-      runId,
-      opCount,
+      runId: envelope.run.runId,
+      opCount: envelope.ops.length,
     });
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : 'Unknown error';
     const requiresLogin =
-      errorMessage.toLowerCase().includes('login') ||
-      errorMessage.toLowerCase().includes('session') ||
-      errorMessage.toLowerCase().includes('401') ||
-      errorMessage.toLowerCase().includes('unauthorized');
+      err instanceof SyncError
+        ? err.phase === 'portal'
+        : errorMessage.toLowerCase().includes('login') ||
+          errorMessage.toLowerCase().includes('session') ||
+          errorMessage.toLowerCase().includes('401') ||
+          errorMessage.toLowerCase().includes('unauthorized');
 
     chrome.runtime.sendMessage({
       type: 'SYNC_FAILED',
-      runId,
+      runId: msg.runId,
       errorMessage,
       requiresLogin,
       provider,
       baseUrl,
     });
   }
-}
-
-function buildEnvelope(params: {
-  readonly runId: string;
-  readonly now: string;
-  readonly provider: string;
-  readonly adapterId: string;
-  readonly adapterVersion: string;
-  readonly sourceId: string;
-  readonly baseUrl: string;
-  readonly ops: readonly unknown[];
-}): ISlcIngestEnvelopeV1 {
-  return {
-    schemaVersion: SLC_INGEST_SCHEMA_VERSION_V1,
-    run: {
-      runId: params.runId,
-      startedAt: params.now,
-      endedAt: new Date().toISOString(),
-      provider: params.provider,
-      adapterId: params.adapterId,
-      adapterVersion: params.adapterVersion,
-      mode: 'delta',
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      meta: {
-        clientType: 'browser-extension',
-        extensionVersion: EXTENSION_VERSION,
-        publisher: 'scholaracle',
-      },
-    },
-    source: {
-      sourceId: params.sourceId,
-      displayName: `${params.provider} (extension)`,
-      portalBaseUrl: params.baseUrl,
-    },
-    ops: params.ops as ISlcIngestEnvelopeV1['ops'],
-  };
 }

--- a/packages/browser-extension/src/lib/ingest.ts
+++ b/packages/browser-extension/src/lib/ingest.ts
@@ -1,45 +1,78 @@
 /**
- * Three-step ingest upload (runs → envelope → complete) for the extension.
- * Mirrors the pattern used in the mobile SyncOrchestrator.
+ * Ingest uploader for the browser extension.
+ *
+ * Implements IIngestUploader from @scholaracle/scraper-core using the
+ * three-step canonical protocol:
+ *   POST /api/ingest/v1/runs
+ *   POST /api/ingest/v1/runs/:runId/envelope
+ *   POST /api/ingest/v1/runs/:runId/complete
  */
 
 import type { ISlcIngestEnvelopeV1 } from '@scholaracle/contracts';
+import type { IIngestUploader } from '@scholaracle/scraper-core';
 
-export async function uploadEnvelope(
-  envelope: ISlcIngestEnvelopeV1,
-  connectorToken: string,
-  apiBaseUrl: string
-): Promise<void> {
-  const base = apiBaseUrl.replace(/\/$/, '');
-  const headers = {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${connectorToken}`,
-  };
+export class ExtensionIngestUploader implements IIngestUploader {
+  private readonly base: string;
+  private readonly headers: Record<string, string>;
 
-  const runRes = await fetch(`${base}/api/ingest/v1/runs`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      runId: envelope.run.runId,
-      provider: envelope.run.provider,
-      adapterId: envelope.run.adapterId,
-      sourceId: envelope.source.sourceId,
-      startedAt: envelope.run.startedAt,
-    }),
-  });
-  if (!runRes.ok) throw new Error(`Run registration failed: ${runRes.status}`);
+  constructor(apiBaseUrl: string, connectorToken: string) {
+    this.base = apiBaseUrl.replace(/\/$/, '');
+    this.headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${connectorToken}`,
+    };
+  }
 
-  const envelopeRes = await fetch(`${base}/api/ingest/v1/envelope`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(envelope),
-  });
-  if (!envelopeRes.ok) throw new Error(`Envelope upload failed: ${envelopeRes.status}`);
+  async upload(envelope: ISlcIngestEnvelopeV1): Promise<void> {
+    const runId = envelope.run.runId;
 
-  const completeRes = await fetch(`${base}/api/ingest/v1/complete`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({ runId: envelope.run.runId, status: 'success' }),
-  });
-  if (!completeRes.ok) throw new Error(`Run completion failed: ${completeRes.status}`);
+    const runRes = await fetch(`${this.base}/api/ingest/v1/runs`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({
+        runId,
+        provider: envelope.run.provider,
+        adapterId: envelope.run.adapterId,
+        sourceId: envelope.source.sourceId,
+        startedAt: envelope.run.startedAt,
+      }),
+    });
+    if (!runRes.ok) throw new Error(`Run registration failed: ${runRes.status}`);
+
+    const body = (await runRes.json()) as Partial<{ runId: string }>;
+    const serverRunId = body.runId ?? runId;
+
+    const envelopeRes = await fetch(`${this.base}/api/ingest/v1/runs/${serverRunId}/envelope`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({ ...envelope, run: { ...envelope.run, runId: serverRunId } }),
+    });
+    if (!envelopeRes.ok) throw new Error(`Envelope upload failed: ${envelopeRes.status}`);
+
+    const completeRes = await fetch(`${this.base}/api/ingest/v1/runs/${serverRunId}/complete`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({ runId: serverRunId, status: 'success' }),
+    });
+    if (!completeRes.ok) throw new Error(`Run completion failed: ${completeRes.status}`);
+  }
+
+  async reportFailure(runId: string, sourceId: string, error: string): Promise<void> {
+    try {
+      const runRes = await fetch(`${this.base}/api/ingest/v1/runs`, {
+        method: 'POST',
+        headers: this.headers,
+        body: JSON.stringify({ runId, sourceId }),
+      });
+      const body = runRes.ok ? ((await runRes.json()) as Partial<{ runId: string }>) : { runId };
+      const serverRunId = body.runId ?? runId;
+      await fetch(`${this.base}/api/ingest/v1/runs/${serverRunId}/complete`, {
+        method: 'POST',
+        headers: this.headers,
+        body: JSON.stringify({ runId: serverRunId, status: 'failed', error }),
+      });
+    } catch {
+      // best effort
+    }
+  }
 }

--- a/packages/contracts/src/types/api/index.ts
+++ b/packages/contracts/src/types/api/index.ts
@@ -6,4 +6,5 @@ export * from './auth';
 export * from './integrations';
 export * from './account';
 export * from './ingest';
+export * from './sourceInvite';
 export * from './materials';

--- a/packages/contracts/src/types/api/sourceInvite.test.ts
+++ b/packages/contracts/src/types/api/sourceInvite.test.ts
@@ -1,0 +1,81 @@
+/**
+ * SOURCE_INVITE.md §3 — payload / issue-response allowlists and assertNoSecrets.
+ */
+
+import {
+  SOURCE_INVITE_ADAPTER_IDS,
+  SOURCE_INVITE_ISSUE_RESPONSE_KEYS,
+  SOURCE_INVITE_PAYLOAD_KEYS,
+  SOURCE_INVITE_PROVIDERS,
+  SOURCE_INVITE_PROVIDER_NAMES,
+  assertNoSecrets,
+  sanitizeInstallToken,
+  type ISourceInviteIssueResponse,
+  type ISourceInvitePayload,
+} from './sourceInvite';
+
+const AVA_PAYLOAD: ISourceInvitePayload = {
+  provider: 'skyward',
+  adapterId: SOURCE_INVITE_ADAPTER_IDS.skyward,
+  portalBaseUrl: 'https://skyward.iscorp.com',
+  displayName: 'Skyward Family Access (skyward.iscorp.com)',
+  studentId: 'stu-mongo-1',
+  studentExternalId: 'ava-lewis',
+  institutionExternalId: 'skyward.iscorp.com',
+};
+
+describe('source invite contracts', () => {
+  it('SOURCE_INVITE_PROVIDERS is exactly canvas/skyward/aeries', () => {
+    expect([...SOURCE_INVITE_PROVIDERS]).toEqual(['canvas', 'skyward', 'aeries']);
+  });
+
+  it('payload JSON keys are exactly the allowlist', () => {
+    expect(Object.keys(AVA_PAYLOAD).sort()).toEqual([...SOURCE_INVITE_PAYLOAD_KEYS].sort());
+  });
+
+  it('issue response type allowlist excludes token and landingUrl', () => {
+    const sample: ISourceInviteIssueResponse = {
+      success: true,
+      expiresAt: '2026-08-22T00:00:00.000Z',
+      emailedTo: 'parent@example.com',
+    };
+    const keys = Object.keys(sample);
+    expect(keys.sort()).toEqual([...SOURCE_INVITE_ISSUE_RESPONSE_KEYS].sort());
+    expect(keys).not.toContain('token');
+    expect(keys).not.toContain('landingUrl');
+    expect(keys).not.toContain('portalBaseUrl');
+    expect(keys).not.toContain('studentExternalId');
+  });
+
+  it('assertNoSecrets accepts a valid payload', () => {
+    expect(() => assertNoSecrets(AVA_PAYLOAD)).not.toThrow();
+  });
+
+  it('payload JSON fails assertNoSecrets if password is added', () => {
+    expect(() => assertNoSecrets({ ...AVA_PAYLOAD, password: 'secret' })).toThrow(/secret/i);
+  });
+
+  it('rejects username, connector-like jwt, and nested secrets', () => {
+    expect(() => assertNoSecrets({ username: 'a' })).toThrow();
+    expect(() => assertNoSecrets({ jwt: 'x' })).toThrow();
+    expect(() => assertNoSecrets({ creds: { token: 'x' } })).toThrow();
+  });
+
+  it('allows redeem top-level token when opted in', () => {
+    const token = 'ab'.repeat(32);
+    expect(() => assertNoSecrets({ token }, { allowKeys: new Set(['token']) })).not.toThrow();
+  });
+
+  it('sanitizeInstallToken accepts 64 hex and rejects garbage', () => {
+    const token = 'ab'.repeat(32);
+    expect(sanitizeInstallToken(token)).toBe(token);
+    expect(sanitizeInstallToken('<script>')).toBe('');
+    expect(sanitizeInstallToken('abc')).toBe('');
+    expect(sanitizeInstallToken(null)).toBe('');
+  });
+
+  it('maps providers to mobile adapter ids and display names', () => {
+    expect(SOURCE_INVITE_ADAPTER_IDS.skyward).toBe('com.skyward.iscorp');
+    expect(SOURCE_INVITE_PROVIDER_NAMES.skyward).toBe('Skyward Family Access');
+  });
+});

--- a/packages/contracts/src/types/api/sourceInvite.ts
+++ b/packages/contracts/src/types/api/sourceInvite.ts
@@ -1,0 +1,112 @@
+/**
+ * Wire contracts for source invites (SOURCE_INVITE.md §3).
+ *
+ * Server is source of truth: packages/api/src/routes/source-invites/.
+ * Payload types must not declare password, username, cookie, secret, jwt, or credential.
+ */
+
+import { ValidationError } from '../../errors';
+
+export const SOURCE_INVITE_PROVIDERS = ['canvas', 'skyward', 'aeries'] as const;
+export type SourceInviteProvider = (typeof SOURCE_INVITE_PROVIDERS)[number];
+
+export const SOURCE_INVITE_PAYLOAD_KEYS = [
+  'provider',
+  'adapterId',
+  'portalBaseUrl',
+  'displayName',
+  'studentId',
+  'studentExternalId',
+  'institutionExternalId',
+] as const;
+
+export const SOURCE_INVITE_ISSUE_RESPONSE_KEYS = ['success', 'expiresAt', 'emailedTo'] as const;
+
+export const SOURCE_INVITE_ADAPTER_IDS: Readonly<Record<SourceInviteProvider, string>> = {
+  canvas: 'com.instructure.canvas',
+  skyward: 'com.skyward.iscorp',
+  aeries: 'com.aeries.portal',
+};
+
+export const SOURCE_INVITE_PROVIDER_NAMES: Readonly<Record<SourceInviteProvider, string>> = {
+  canvas: 'Canvas LMS',
+  skyward: 'Skyward Family Access',
+  aeries: 'Aeries Parent Portal',
+};
+
+export const SOURCE_INVITE_TOKEN_BYTES = 32;
+export const SOURCE_INVITE_TOKEN_HEX_LENGTH = SOURCE_INVITE_TOKEN_BYTES * 2;
+export const SOURCE_INVITE_TOKEN_HEX_PATTERN = /^[a-f0-9]{64}$/i;
+export const SOURCE_INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+export const SOURCE_INVITE_REDEEM_ERROR = 'This install link expired or is not for this account.';
+
+/** Exact key names that must never appear on a source-invite payload. */
+const SECRET_KEY =
+  /^(user|username|pass|password|token|secret|cookie|credential|jwt|authorization)$/i;
+
+export interface ISourceInvitePayload {
+  readonly provider: SourceInviteProvider;
+  readonly adapterId: string;
+  readonly portalBaseUrl: string;
+  readonly displayName: string;
+  readonly studentId: string;
+  readonly studentExternalId: string;
+  readonly institutionExternalId: string;
+}
+
+export interface ISourceInviteIssueRequest {
+  readonly studentId: string;
+  readonly provider: SourceInviteProvider;
+  readonly portalBaseUrl: string;
+  readonly displayName?: string;
+}
+
+export interface ISourceInviteIssueResponse {
+  readonly success: true;
+  readonly expiresAt: string;
+  readonly emailedTo: string;
+}
+
+export interface ISourceInviteRedeemRequest {
+  readonly token: string;
+}
+
+export interface ISourceInviteRedeemResponse {
+  readonly success: true;
+  readonly invite: ISourceInvitePayload;
+}
+
+export interface IAssertNoSecretsOptions {
+  /** Keys allowed only at the top level (e.g. redeem `token`, stored `tokenHash`). */
+  readonly allowKeys?: ReadonlySet<string>;
+}
+
+/**
+ * Reject objects whose keys look like secrets (SOURCE_INVITE.md §5).
+ * Walks nested plain objects. `allowKeys` apply at the top level only.
+ */
+export function assertNoSecrets(record: unknown, options?: IAssertNoSecretsOptions): void {
+  walkNoSecrets(record, options?.allowKeys ?? new Set(), true);
+}
+
+function walkNoSecrets(value: unknown, allowKeys: ReadonlySet<string>, isTop: boolean): void {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return;
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    const allowed = isTop && allowKeys.has(key);
+    if (!allowed && SECRET_KEY.test(key)) {
+      throw new ValidationError('Request must not include secrets');
+    }
+    walkNoSecrets(child, allowKeys, false);
+  }
+}
+
+/** Return the token when it is 64 hex chars; otherwise empty string (SOURCE_INVITE.md §5.4). */
+export function sanitizeInstallToken(raw: string | null | undefined): string {
+  if (typeof raw !== 'string') return '';
+  const trimmed = raw.trim();
+  return SOURCE_INVITE_TOKEN_HEX_PATTERN.test(trimmed) ? trimmed.toLowerCase() : '';
+}
+
+export function isSourceInviteProvider(value: string): value is SourceInviteProvider {
+  return (SOURCE_INVITE_PROVIDERS as readonly string[]).includes(value);
+}

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -44,6 +44,7 @@ export * from './repositories/WebhookEventRepository';
 export * from './repositories/IngestDeviceAuthRepository';
 export * from './repositories/IngestSourceRepository';
 export * from './repositories/IngestRunRepository';
+export * from './repositories/SourceInviteRepository';
 
 // Helpers (semester / term filtering)
 export { getCurrentSemesterStart } from './helpers/getCurrentSemesterStart';

--- a/packages/database/src/indexes.ts
+++ b/packages/database/src/indexes.ts
@@ -188,6 +188,17 @@ export async function createIndexes(database: Db): Promise<void> {
   await slcComments.createIndex({ userId: 1, assignmentExternalId: 1, deletedAt: 1 });
   await slcComments.createIndex({ authorUserId: 1 });
 
+  const sourceInvites = database.collection('source_invites');
+  await sourceInvites.createIndex({ tokenHash: 1 }, { unique: true });
+  await sourceInvites.createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+  await sourceInvites.createIndex({
+    userId: 1,
+    'payload.studentId': 1,
+    'payload.provider': 1,
+    'payload.institutionExternalId': 1,
+    consumedAt: 1,
+  });
+
   // eslint-disable-next-line no-console
   console.log('Database indexes created successfully');
 }

--- a/packages/database/src/repositories/SourceInviteRepository/ISourceInviteStore.ts
+++ b/packages/database/src/repositories/SourceInviteRepository/ISourceInviteStore.ts
@@ -1,0 +1,24 @@
+import type { ISourceInvitePayload, SourceInviteProvider } from '@scholaracle/contracts';
+
+export interface ISourceInviteRecord {
+  readonly id: string;
+  readonly userId: string;
+  readonly tokenHash: string;
+  readonly payload: ISourceInvitePayload;
+  readonly expiresAt: Date;
+  readonly createdAt: Date;
+  readonly consumedAt: Date | null;
+}
+
+export interface ISourceInviteStore {
+  insert(record: Omit<ISourceInviteRecord, 'id'>): Promise<ISourceInviteRecord>;
+  findByHash(tokenHash: string): Promise<ISourceInviteRecord | null>;
+  consumeIfOpen(id: string, now: Date): Promise<boolean>;
+  invalidateOpen(params: {
+    readonly userId: string;
+    readonly studentId: string;
+    readonly provider: SourceInviteProvider;
+    readonly institutionExternalId: string;
+    readonly now: Date;
+  }): Promise<number>;
+}

--- a/packages/database/src/repositories/SourceInviteRepository/SourceInviteRepository.test.ts
+++ b/packages/database/src/repositories/SourceInviteRepository/SourceInviteRepository.test.ts
@@ -1,0 +1,121 @@
+/**
+ * SOURCE_INVITE.md §4.2
+ */
+
+import { MongoClient, ObjectId, type Db } from 'mongodb';
+import { SOURCE_INVITE_ADAPTER_IDS, type ISourceInvitePayload } from '@scholaracle/contracts';
+import { SourceInviteRepository } from './SourceInviteRepository';
+
+const AVA_PAYLOAD: ISourceInvitePayload = {
+  provider: 'skyward',
+  adapterId: SOURCE_INVITE_ADAPTER_IDS.skyward,
+  portalBaseUrl: 'https://skyward.iscorp.com',
+  displayName: 'Skyward Family Access (skyward.iscorp.com)',
+  studentId: 'stu-mongo-1',
+  studentExternalId: 'ava-lewis',
+  institutionExternalId: 'skyward.iscorp.com',
+};
+
+describe('SourceInviteRepository', () => {
+  let client: MongoClient;
+  let database: Db;
+  let repository: SourceInviteRepository;
+
+  beforeAll(async () => {
+    const uri = process.env['MONGODB_URI'] ?? 'mongodb://localhost:27017';
+    client = new MongoClient(uri);
+    await client.connect();
+    database = client.db('scholaracle_source_invite_test');
+    repository = new SourceInviteRepository(database);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  beforeEach(async () => {
+    await database.collection('source_invites').deleteMany({});
+  });
+
+  it('insert then findByHash returns payload; document has tokenHash not token', async () => {
+    const userId = new ObjectId().toString();
+    const now = new Date();
+    const inserted = await repository.insert({
+      userId,
+      tokenHash: 'hash-1',
+      payload: AVA_PAYLOAD,
+      expiresAt: new Date(now.getTime() + 3600000),
+      createdAt: now,
+      consumedAt: null,
+    });
+
+    const found = await repository.findByHash('hash-1');
+    expect(found?.payload).toEqual(AVA_PAYLOAD);
+    expect(found?.userId).toBe(userId);
+    expect(found?.id).toBe(inserted.id);
+
+    const doc = await database.collection('source_invites').findOne({ tokenHash: 'hash-1' });
+    expect(doc).not.toBeNull();
+    expect(doc).not.toHaveProperty('token');
+    expect(doc?.['tokenHash']).toBe('hash-1');
+  });
+
+  it('consumeIfOpen true once, false second time', async () => {
+    const now = new Date();
+    const inserted = await repository.insert({
+      userId: new ObjectId().toString(),
+      tokenHash: 'hash-2',
+      payload: AVA_PAYLOAD,
+      expiresAt: new Date(now.getTime() + 3600000),
+      createdAt: now,
+      consumedAt: null,
+    });
+    expect(await repository.consumeIfOpen(inserted.id, now)).toBe(true);
+    expect(await repository.consumeIfOpen(inserted.id, now)).toBe(false);
+  });
+
+  it('consumeIfOpen is false when expired', async () => {
+    const now = new Date();
+    const inserted = await repository.insert({
+      userId: new ObjectId().toString(),
+      tokenHash: 'hash-3',
+      payload: AVA_PAYLOAD,
+      expiresAt: new Date(now.getTime() - 1000),
+      createdAt: now,
+      consumedAt: null,
+    });
+    expect(await repository.consumeIfOpen(inserted.id, now)).toBe(false);
+  });
+
+  it('invalidateOpen sets consumedAt on matching open rows only', async () => {
+    const now = new Date();
+    const userId = new ObjectId().toString();
+    const otherUser = new ObjectId().toString();
+    await repository.insert({
+      userId,
+      tokenHash: 'hash-a',
+      payload: AVA_PAYLOAD,
+      expiresAt: new Date(now.getTime() + 3600000),
+      createdAt: now,
+      consumedAt: null,
+    });
+    await repository.insert({
+      userId: otherUser,
+      tokenHash: 'hash-b',
+      payload: AVA_PAYLOAD,
+      expiresAt: new Date(now.getTime() + 3600000),
+      createdAt: now,
+      consumedAt: null,
+    });
+    const n = await repository.invalidateOpen({
+      userId,
+      studentId: AVA_PAYLOAD.studentId,
+      provider: 'skyward',
+      institutionExternalId: AVA_PAYLOAD.institutionExternalId,
+      now,
+    });
+    expect(n).toBe(1);
+    expect((await repository.findByHash('hash-a'))?.consumedAt).toEqual(now);
+    expect((await repository.findByHash('hash-b'))?.consumedAt).toBeNull();
+  });
+});

--- a/packages/database/src/repositories/SourceInviteRepository/SourceInviteRepository.ts
+++ b/packages/database/src/repositories/SourceInviteRepository/SourceInviteRepository.ts
@@ -1,0 +1,88 @@
+import type { Collection, Db } from 'mongodb';
+import { ObjectId } from 'mongodb';
+import type { ISourceInvitePayload, SourceInviteProvider } from '@scholaracle/contracts';
+import type { ISourceInviteRecord, ISourceInviteStore } from './ISourceInviteStore';
+
+interface ISourceInviteDocument {
+  readonly _id?: ObjectId;
+  readonly userId: ObjectId;
+  readonly tokenHash: string;
+  readonly payload: ISourceInvitePayload;
+  readonly expiresAt: Date;
+  readonly createdAt: Date;
+  readonly consumedAt: Date | null;
+}
+
+function toRecord(doc: ISourceInviteDocument & { _id: ObjectId }): ISourceInviteRecord {
+  return {
+    id: doc._id.toString(),
+    userId: doc.userId.toString(),
+    tokenHash: doc.tokenHash,
+    payload: doc.payload,
+    expiresAt: doc.expiresAt,
+    createdAt: doc.createdAt,
+    consumedAt: doc.consumedAt,
+  };
+}
+
+/**
+ * Hashed source-invite tokens. Never stores the raw token (SOURCE_INVITE.md §4.2).
+ */
+export class SourceInviteRepository implements ISourceInviteStore {
+  private readonly _collection: Collection<ISourceInviteDocument>;
+
+  constructor(database: Db) {
+    this._collection = database.collection<ISourceInviteDocument>('source_invites');
+  }
+
+  public async insert(record: Omit<ISourceInviteRecord, 'id'>): Promise<ISourceInviteRecord> {
+    const document: ISourceInviteDocument = {
+      userId: new ObjectId(record.userId),
+      tokenHash: record.tokenHash,
+      payload: record.payload,
+      expiresAt: record.expiresAt,
+      createdAt: record.createdAt,
+      consumedAt: record.consumedAt,
+    };
+    const result = await this._collection.insertOne(document);
+    return toRecord({ ...document, _id: result.insertedId });
+  }
+
+  public async findByHash(tokenHash: string): Promise<ISourceInviteRecord | null> {
+    const doc = await this._collection.findOne({ tokenHash });
+    if (!doc?._id) return null;
+    return toRecord({ ...doc, _id: doc._id });
+  }
+
+  public async consumeIfOpen(id: string, now: Date): Promise<boolean> {
+    const result = await this._collection.updateOne(
+      {
+        _id: new ObjectId(id),
+        consumedAt: null,
+        expiresAt: { $gt: now },
+      },
+      { $set: { consumedAt: now } }
+    );
+    return result.modifiedCount === 1;
+  }
+
+  public async invalidateOpen(params: {
+    readonly userId: string;
+    readonly studentId: string;
+    readonly provider: SourceInviteProvider;
+    readonly institutionExternalId: string;
+    readonly now: Date;
+  }): Promise<number> {
+    const result = await this._collection.updateMany(
+      {
+        userId: new ObjectId(params.userId),
+        'payload.studentId': params.studentId,
+        'payload.provider': params.provider,
+        'payload.institutionExternalId': params.institutionExternalId,
+        consumedAt: null,
+      },
+      { $set: { consumedAt: params.now } }
+    );
+    return result.modifiedCount;
+  }
+}

--- a/packages/database/src/repositories/SourceInviteRepository/index.ts
+++ b/packages/database/src/repositories/SourceInviteRepository/index.ts
@@ -1,0 +1,2 @@
+export { SourceInviteRepository } from './SourceInviteRepository';
+export type { ISourceInviteStore, ISourceInviteRecord } from './ISourceInviteStore';

--- a/packages/e2e/tests/server-sync-e2e.spec.ts
+++ b/packages/e2e/tests/server-sync-e2e.spec.ts
@@ -1,20 +1,14 @@
 /**
- * Server-side sync E2E: Login → Add source → Store credentials → Trigger sync → Verify results.
+ * Server-side ingest guardrails E2E: asserts that the server correctly rejects
+ * portal login credentials and HTML-provider sync triggers.
  *
- * This test exercises the full server-side scraping pipeline:
- * 1. Log in as the test parent, capture auth token
- * 2. Use an existing seeded student
- * 3. Add a Canvas data source with portalBaseUrl (via API)
- * 4. Store encrypted credentials (username/password)
- * 5. Trigger a manual sync via API
- * 6. Poll sync run status until worker completes (scraper runs on Docker worker)
- * 7-9. Verify sync run, data source, and capacity endpoint
+ * The old server-scraping pipeline (Canvas/Skyward/Aeries via Playwright workers)
+ * has been retired. Extraction now runs client-side (iOS app, browser extension, CLI).
+ * These tests verify the server enforces that boundary at every entry point.
  *
  * Prerequisites:
- * - Docker workers running: `./scripts/build-workers.sh && docker compose up -d mongodb workers api`
- * - API must have CREDENTIALS_ENCRYPTION_KEY set
- * - Web dev server on port 2800 (for login/auth token capture)
- * - Set env vars: TEST_CANVAS_URL, TEST_CANVAS_EMAIL, TEST_CANVAS_PASSWORD
+ *   - API running (local Docker or Railway dev)
+ *   - Standard test fixtures (seeded parent account)
  *
  * Run:
  *   npx playwright test server-sync-e2e --project=server-sync-e2e --no-deps
@@ -22,35 +16,25 @@
 import { test, expect } from '../fixtures/auth';
 
 const API_BASE = process.env.API_BASE_URL ?? 'http://localhost:2801';
-const TEST_CANVAS_URL = process.env.TEST_CANVAS_URL ?? '';
-const TEST_CANVAS_EMAIL = process.env.TEST_CANVAS_EMAIL ?? '';
-const TEST_CANVAS_PASSWORD = process.env.TEST_CANVAS_PASSWORD ?? '';
 
-const hasEnv = !!TEST_CANVAS_URL && !!TEST_CANVAS_EMAIL && !!TEST_CANVAS_PASSWORD;
-
-test.describe('Server-side sync: worker scrapes Canvas via queue', () => {
-  test.skip(!hasEnv, 'Set TEST_CANVAS_URL, TEST_CANVAS_EMAIL, TEST_CANVAS_PASSWORD to run');
-  test.setTimeout(300_000); // 5 minutes — scraper can take 90s+
-
+test.describe('Server enforces client-side-only scraping guardrails', () => {
   let authToken: string;
   let studentId: string;
-  let sourceId: string;
+  let canvasSourceId: string;
 
-  test.describe.serial('Full server sync flow', () => {
-    // -----------------------------------------------------------------------
-    // Step 1: Login and capture auth token
-    // -----------------------------------------------------------------------
+  test.describe.serial('Guardrail assertions', () => {
+    // -------------------------------------------------------------------------
+    // Step 1: Login
+    // -------------------------------------------------------------------------
     test('1. Login as parent and get auth token', async ({ page, loginAsRole }) => {
       await loginAsRole('parent');
-
-      // Extract token from localStorage
       authToken = await page.evaluate(() => localStorage.getItem('auth_token') ?? '');
       expect(authToken).toBeTruthy();
     });
 
-    // -----------------------------------------------------------------------
-    // Step 2: Get an existing student (seeded by global setup)
-    // -----------------------------------------------------------------------
+    // -------------------------------------------------------------------------
+    // Step 2: Get a seeded student
+    // -------------------------------------------------------------------------
     test('2. Get existing test student', async ({ request }) => {
       const res = await request.get(`${API_BASE}/api/students`, {
         headers: { Authorization: `Bearer ${authToken}` },
@@ -64,173 +48,78 @@ test.describe('Server-side sync: worker scrapes Canvas via queue', () => {
       expect(studentId).toBeTruthy();
     });
 
-    // -----------------------------------------------------------------------
-    // Step 3: Add a Canvas data source
-    // -----------------------------------------------------------------------
-    test('3. Add Canvas data source', async ({ request }) => {
+    // -------------------------------------------------------------------------
+    // Step 3: Add a Canvas source (no credentials)
+    // -------------------------------------------------------------------------
+    test('3. Add Canvas data source (no credentials)', async ({ request }) => {
       const res = await request.post(`${API_BASE}/api/students/${studentId}/sources`, {
         headers: { Authorization: `Bearer ${authToken}` },
         data: {
           provider: 'canvas',
           adapterId: 'canvas::default',
-          displayName: 'LDISD Canvas',
-          portalBaseUrl: TEST_CANVAS_URL,
+          displayName: 'Test Canvas',
+          portalBaseUrl: 'https://canvas.test.example.com',
           schedule: 'daily',
-          dataTypes: ['grades', 'assignments', 'courses'],
+          dataTypes: ['grades', 'assignments'],
         },
       });
       expect(res.status()).toBeLessThan(400);
       const body = await res.json();
-      sourceId = body.source?.id ?? body.id;
-      expect(sourceId).toBeTruthy();
+      canvasSourceId = body.source?.id ?? body.id;
+      expect(canvasSourceId).toBeTruthy();
     });
 
-    // -----------------------------------------------------------------------
-    // Step 4: Store encrypted credentials
-    // -----------------------------------------------------------------------
-    test('4. Store Canvas credentials', async ({ request }) => {
+    // -------------------------------------------------------------------------
+    // Step 4: Attempting to store portal login credentials MUST be rejected
+    // -------------------------------------------------------------------------
+    test('4. PUT login credentials for Canvas returns 400', async ({ request }) => {
       const res = await request.put(
-        `${API_BASE}/api/students/${studentId}/sources/${sourceId}/credentials`,
+        `${API_BASE}/api/students/${studentId}/sources/${canvasSourceId}/credentials`,
         {
           headers: { Authorization: `Bearer ${authToken}` },
           data: {
             authType: 'login',
-            username: TEST_CANVAS_EMAIL,
-            password: TEST_CANVAS_PASSWORD,
+            username: 'test@example.com',
+            password: 'test-password',
           },
         }
       );
-      expect(res.status()).toBeLessThan(400);
+      expect(res.status()).toBe(400);
       const body = await res.json();
-      expect(body.success).toBe(true);
-      expect(body.hasCredentials).toBe(true);
+      expect(body.success).toBeFalsy();
     });
 
-    // -----------------------------------------------------------------------
-    // Step 5: Navigate to student and trigger sync via UI
-    // -----------------------------------------------------------------------
-    test('5. Trigger manual sync via API', async ({ request }) => {
-      const triggerRes = await request.post(
-        `${API_BASE}/api/students/${studentId}/sources/${sourceId}/runs/trigger`,
-        { headers: { Authorization: `Bearer ${authToken}` } }
-      );
-      expect(triggerRes.status()).toBeLessThan(400);
-      const body = await triggerRes.json();
-      expect(body.runId).toBeTruthy();
-    });
-
-    // -----------------------------------------------------------------------
-    // Step 6: Poll sync run until completion (max 3 minutes)
-    // -----------------------------------------------------------------------
-    test('6. Wait for sync to complete', async ({ request }) => {
-      const maxWait = 180_000; // 3 minutes
-      const pollInterval = 5_000;
-      const start = Date.now();
-      let lastStatus = 'unknown';
-
-      while (Date.now() - start < maxWait) {
-        // Check sync runs for this student (via sync API, not ingest runs)
-        const runsRes = await request.get(
-          `${API_BASE}/api/sync/students/${studentId}/runs`,
-          { headers: { Authorization: `Bearer ${authToken}` } }
-        );
-
-        if (runsRes.ok()) {
-          const body = await runsRes.json();
-          const runs = body.runs ?? body;
-
-          if (Array.isArray(runs) && runs.length > 0) {
-            const latest = runs[0];
-            lastStatus = latest.status;
-
-            if (lastStatus === 'committed' || lastStatus === 'completed') {
-              // Scraper ran and data was committed
-              return;
-            }
-            if (lastStatus === 'failed') {
-              // Scraper ran but ingest submission may have failed — still proves pipeline works
-              if (latest.error?.includes('Ingest envelope submit failed')) {
-                // Scraper scraped successfully but post-processing failed — acceptable for pipeline test
-                console.log(`  Sync completed with ingest error: ${latest.error}`);
-                return;
-              }
-              throw new Error(`Sync failed: ${latest.error ?? 'unknown error'}`);
-            }
-          }
-        }
-
-        // Also check via /api/sync/capacity to see worker status
-        const capRes = await request.get(`${API_BASE}/api/sync/capacity`, {
-          headers: { Authorization: `Bearer ${authToken}` },
-        });
-        if (capRes.ok()) {
-          const cap = await capRes.json();
-          const elapsed = Math.round((Date.now() - start) / 1000);
-          // Log progress (visible in Playwright report)
-          console.log(
-            `  [${elapsed}s] status=${lastStatus}, queue=${cap.queue?.pending ?? '?'}, ` +
-              `workers=${cap.capacity?.workerCount ?? 0}, active=${cap.capacity?.activeJobs ?? 0}`
-          );
-        }
-
-        await new Promise((r) => setTimeout(r, pollInterval));
-      }
-
-      throw new Error(`Sync did not complete within 3 minutes (last status: ${lastStatus})`);
-    });
-
-    // -----------------------------------------------------------------------
-    // Step 7: Verify sync run completed via API
-    // -----------------------------------------------------------------------
-    test('7. Verify sync run completed', async ({ request }) => {
-      const runsRes = await request.get(
-        `${API_BASE}/api/sync/students/${studentId}/runs`,
-        { headers: { Authorization: `Bearer ${authToken}` } }
-      );
-      expect(runsRes.status()).toBe(200);
-      const body = await runsRes.json();
-      const runs = body.runs ?? body;
-      expect(Array.isArray(runs)).toBe(true);
-      expect(runs.length).toBeGreaterThan(0);
-
-      const latest = runs[0];
-      // Run should have completed (or failed at ingest stage — scraper still ran)
-      expect(['committed', 'completed', 'failed']).toContain(latest.status);
-      expect(latest.completedAt).toBeTruthy();
-    });
-
-    // -----------------------------------------------------------------------
-    // Step 8: Verify data source shows last scrape timestamp
-    // -----------------------------------------------------------------------
-    test('8. Verify data source updated', async ({ request }) => {
-      const res = await request.get(
-        `${API_BASE}/api/students/${studentId}/sources`,
-        { headers: { Authorization: `Bearer ${authToken}` } }
-      );
-      expect(res.status()).toBe(200);
-      const sources = await res.json();
-      const source = Array.isArray(sources)
-        ? sources.find((s: { id?: string }) => s.id === sourceId)
-        : null;
-      // Source should exist (may or may not have lastScraped depending on ingest success)
-      expect(source).toBeTruthy();
-    });
-
-    // -----------------------------------------------------------------------
-    // Step 9: Check capacity endpoint shows worker info
-    // -----------------------------------------------------------------------
-    test('9. Verify capacity endpoint', async ({ request }) => {
-      const res = await request.get(`${API_BASE}/api/sync/capacity`, {
+    // -------------------------------------------------------------------------
+    // Step 5: Attempting to trigger server-side sync for Canvas MUST be rejected
+    // -------------------------------------------------------------------------
+    test('5. POST sync trigger for Canvas returns 400', async ({ request }) => {
+      const studentsRes = await request.get(`${API_BASE}/api/students`, {
         headers: { Authorization: `Bearer ${authToken}` },
       });
-      expect(res.status()).toBe(200);
-      const body = await res.json();
+      const body = await studentsRes.json();
+      const students = body.students ?? body;
+      const student = Array.isArray(students) ? students.find((s: { id?: string; _id?: string }) => (s.id ?? s._id) === studentId) : null;
+      const dsIndex = student?.dataSources?.findIndex(
+        (ds: { provider?: string }) => ds.provider === 'canvas'
+      ) ?? 0;
 
-      expect(body.queue).toBeDefined();
-      expect(body.capacity).toBeDefined();
-      expect(body.capacity.workerCount).toBeGreaterThanOrEqual(0);
-      expect(body.workers).toBeDefined();
-      expect(Array.isArray(body.workers)).toBe(true);
+      const syncRes = await request.post(
+        `${API_BASE}/api/sync/students/${studentId}/${dsIndex}`,
+        { headers: { Authorization: `Bearer ${authToken}` } }
+      );
+      expect(syncRes.status()).toBe(400);
+      const syncBody = await syncRes.json();
+      expect(syncBody.success).toBeFalsy();
+    });
+
+    // -------------------------------------------------------------------------
+    // Step 6: Google OAuth endpoints return 410 Gone
+    // -------------------------------------------------------------------------
+    test('6. GET /api/oauth/google/authorize returns 410', async ({ request }) => {
+      const res = await request.get(`${API_BASE}/api/oauth/google/authorize`, {
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+      expect(res.status()).toBe(410);
     });
   });
 });

--- a/packages/mobile/App.tsx
+++ b/packages/mobile/App.tsx
@@ -26,7 +26,12 @@ import { isDiagDeepLink } from './src/demo/diagDeepLink';
 import { installDiagCapture, log, openDiagPanel, unlockDiag } from './src/diag';
 import { DebugOverlay } from './src/components/debug/DebugOverlay';
 import { DeployStamp } from './src/components/DeployStamp';
-import type { ICourseGrade, ICourseGradeAssignment } from '@scholaracle/contracts';
+import type { ICourseGrade, ICourseGradeAssignment, ISourceInvitePayload } from '@scholaracle/contracts';
+import { handleInstallLink, redeemPendingInstall } from './src/install/handleInstallLink';
+import { installSourceLinkParser } from './src/install/installSourceDeepLink';
+import { pendingSourceInviteStore } from './src/install/pendingSourceInviteStore';
+import { sourceInviteApplier } from './src/install/applySourceInvite';
+import { apiClient } from './src/api/client';
 
 // Install capture taps once at module load — before any other code runs.
 installDiagCapture();
@@ -47,6 +52,7 @@ interface INavState {
   readonly syncSource?: IConnectedSource;
   readonly course?: ICourseGrade;
   readonly assignment?: ICourseGradeAssignment;
+  readonly sourceInvite?: ISourceInvitePayload;
 }
 
 function AppContent(): React.ReactElement {
@@ -55,6 +61,7 @@ function AppContent(): React.ReactElement {
   const linkingUrl = useLinkingURL();
   const handledDemoUrl = useRef<string | null>(null);
   const handledDiagUrl = useRef<string | null>(null);
+  const handledInstallUrl = useRef<string | null>(null);
 
   // Trace navigation changes into the diag ring buffer.
   useEffect(() => {
@@ -84,6 +91,43 @@ function AppContent(): React.ReactElement {
       }
     })();
   }, [isLoading, linkingUrl, login]);
+
+  const applyInviteNav = useCallback((payload: ISourceInvitePayload): void => {
+    const student: IStudentListItem = {
+      id: payload.studentId,
+      userId: '',
+      name: payload.displayName,
+      studentId: payload.studentExternalId,
+    };
+    setNav({ view: 'connect-source', student, sourceInvite: payload });
+  }, []);
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (!installSourceLinkParser.isInstallSourceDeepLink(linkingUrl)) return;
+    if (handledInstallUrl.current === linkingUrl) return;
+    handledInstallUrl.current = linkingUrl ?? null;
+    void handleInstallLink(linkingUrl, {
+      parser: installSourceLinkParser,
+      pending: pendingSourceInviteStore,
+      redeem: (token) => apiClient.redeemSourceInvite(token),
+      apply: sourceInviteApplier,
+      isLoggedIn,
+      onApplied: (payload) => applyInviteNav(payload),
+      onError: (message) => Alert.alert('Install link', message),
+    });
+  }, [isLoading, isLoggedIn, linkingUrl, applyInviteNav]);
+
+  useEffect(() => {
+    if (isLoading || !isLoggedIn) return;
+    void redeemPendingInstall({
+      pending: pendingSourceInviteStore,
+      redeem: (token) => apiClient.redeemSourceInvite(token),
+      apply: sourceInviteApplier,
+      onApplied: (payload) => applyInviteNav(payload),
+      onError: (message) => Alert.alert('Install link', message),
+    });
+  }, [isLoading, isLoggedIn, applyInviteNav]);
 
   useEffect(() => {
     if (isLoggedIn) {
@@ -128,8 +172,9 @@ function AppContent(): React.ReactElement {
   if (nav.view === 'connect-source') {
     return (
       <ConnectSourceScreen
-        studentExternalId={nav.student?.studentId}
-        studentId={nav.student?.id}
+        studentExternalId={nav.sourceInvite?.studentExternalId ?? nav.student?.studentId}
+        studentId={nav.sourceInvite?.studentId ?? nav.student?.id}
+        invite={nav.sourceInvite}
         onConnected={() =>
           setNav({ view: nav.student ? 'dashboard' : 'students', student: nav.student })
         }

--- a/packages/mobile/App.tsx
+++ b/packages/mobile/App.tsx
@@ -26,7 +26,11 @@ import { isDiagDeepLink } from './src/demo/diagDeepLink';
 import { installDiagCapture, log, openDiagPanel, unlockDiag } from './src/diag';
 import { DebugOverlay } from './src/components/debug/DebugOverlay';
 import { DeployStamp } from './src/components/DeployStamp';
-import type { ICourseGrade, ICourseGradeAssignment, ISourceInvitePayload } from '@scholaracle/contracts';
+import type {
+  ICourseGrade,
+  ICourseGradeAssignment,
+  ISourceInvitePayload,
+} from '@scholaracle/contracts';
 import { handleInstallLink, redeemPendingInstall } from './src/install/handleInstallLink';
 import { installSourceLinkParser } from './src/install/installSourceDeepLink';
 import { pendingSourceInviteStore } from './src/install/pendingSourceInviteStore';

--- a/packages/mobile/src/api/client.test.ts
+++ b/packages/mobile/src/api/client.test.ts
@@ -801,3 +801,45 @@ describe('session hardening', () => {
     expect(client.sessionEpoch).toBe(before + 1);
   });
 });
+
+describe('ScholarmancyApiClient source invites', () => {
+  let client: ScholarmancyApiClient;
+
+  beforeEach(() => {
+    secureStoreData.clear();
+    wireSecureStoreMock();
+    client = new ScholarmancyApiClient(BASE_URL);
+    secureStoreData.set('slc_access_token', 'jwt-ok');
+  });
+
+  it('redeemSourceInvite maps invite from 200', async () => {
+    const invite = {
+      provider: 'skyward',
+      adapterId: 'com.skyward.iscorp',
+      portalBaseUrl: 'https://skyward.iscorp.com',
+      displayName: 'Skyward Family Access (skyward.iscorp.com)',
+      studentId: 'stu-1',
+      studentExternalId: 'ava-lewis',
+      institutionExternalId: 'skyward.iscorp.com',
+    };
+    mockFetchSequence({ status: 200, body: { success: true, invite } });
+    const result = await client.redeemSourceInvite('ab'.repeat(32));
+    expect(result).toEqual(invite);
+  });
+
+  it('redeemSourceInvite throws on 404', async () => {
+    mockFetchSequence({
+      status: 404,
+      body: { success: false, error: 'This install link expired or is not for this account.' },
+    });
+    await expect(client.redeemSourceInvite('ab'.repeat(32))).rejects.toThrow(/expired/i);
+  });
+
+  it('redeemSourceInvite throws on 401', async () => {
+    mockFetchSequence(
+      { status: 401, body: { success: false, error: 'expired' } },
+      { status: 401, body: { success: false, error: 'expired' } }
+    );
+    await expect(client.redeemSourceInvite('ab'.repeat(32))).rejects.toThrow();
+  });
+});

--- a/packages/mobile/src/api/client.ts
+++ b/packages/mobile/src/api/client.ts
@@ -24,6 +24,10 @@ import type {
   IConnectorTokenResponse,
   IIngestSourceRegisterRequest,
   IIngestRunStartResponse,
+  ISourceInviteIssueRequest,
+  ISourceInviteIssueResponse,
+  ISourceInvitePayload,
+  ISourceInviteRedeemResponse,
 } from '@scholaracle/contracts';
 import { ApiError } from './ApiError';
 import { getDeviceId } from '../device/deviceId';
@@ -318,6 +322,19 @@ export class ScholarmancyApiClient {
       body: JSON.stringify(source),
     });
     if (!res.ok) throw await ApiError.fromResponse(res, 'Source registration');
+  }
+
+  async redeemSourceInvite(token: string): Promise<ISourceInvitePayload> {
+    const res = await this._post<ISourceInviteRedeemResponse>(
+      '/api/source-invites/redeem',
+      { token },
+      true
+    );
+    return res.invite;
+  }
+
+  async issueSourceInvite(request: ISourceInviteIssueRequest): Promise<ISourceInviteIssueResponse> {
+    return this._post<ISourceInviteIssueResponse>('/api/source-invites', request, true);
   }
 
   async uploadEnvelope(envelope: ISlcIngestEnvelopeV1, connectorToken: string): Promise<void> {

--- a/packages/mobile/src/api/interfaces.ts
+++ b/packages/mobile/src/api/interfaces.ts
@@ -8,6 +8,9 @@ import type {
   IStudentListItem,
   IStudentGradesResponse,
   IAuthLoginResponse,
+  ISourceInviteIssueRequest,
+  ISourceInviteIssueResponse,
+  ISourceInvitePayload,
 } from '@scholaracle/contracts';
 
 export interface IAuthSession {
@@ -63,4 +66,9 @@ export interface IRunRecorder {
       errorMessage?: string;
     }
   ): Promise<void>;
+}
+
+export interface ISourceInviteApi {
+  redeemSourceInvite(token: string): Promise<ISourceInvitePayload>;
+  issueSourceInvite(request: ISourceInviteIssueRequest): Promise<ISourceInviteIssueResponse>;
 }

--- a/packages/mobile/src/install/applySourceInvite.test.ts
+++ b/packages/mobile/src/install/applySourceInvite.test.ts
@@ -1,0 +1,45 @@
+/**
+ * SOURCE_INVITE.md §8.2
+ */
+
+import * as SecureStore from 'expo-secure-store';
+import { SOURCE_INVITE_ADAPTER_IDS, type ISourceInvitePayload } from '@scholaracle/contracts';
+import { ConnectedSourceStore } from '../sources/ConnectedSourceStore';
+import { sourceInviteApplier } from './applySourceInvite';
+
+const AVA: ISourceInvitePayload = {
+  provider: 'skyward',
+  adapterId: SOURCE_INVITE_ADAPTER_IDS.skyward,
+  portalBaseUrl: 'https://skyward.iscorp.com',
+  displayName: 'Skyward Family Access (skyward.iscorp.com)',
+  studentId: 'stu-mongo-1',
+  studentExternalId: 'ava-lewis',
+  institutionExternalId: 'skyward.iscorp.com',
+};
+
+describe('applySourceInvite', () => {
+  beforeEach(async () => {
+    const AsyncStorage = (await import('@react-native-async-storage/async-storage')).default;
+    await AsyncStorage.clear();
+    (SecureStore.setItemAsync as jest.Mock).mockClear();
+  });
+
+  it('upserts source without writing SecureStore', async () => {
+    const store = new ConnectedSourceStore();
+    const source = await sourceInviteApplier.apply(AVA, store);
+    expect(source.studentExternalId).toBe('ava-lewis');
+    expect(source.studentExternalId).not.toBe('default');
+    expect(source.sourceId).toBe('local-skyward-skyward.iscorp.com');
+    expect(source.credentialKey).toBe('slc_creds_skyward_skyward.iscorp.com');
+    expect(source.adapterId).toBe('com.skyward.iscorp');
+    expect(SecureStore.setItemAsync).not.toHaveBeenCalled();
+    expect(await store.list()).toHaveLength(1);
+  });
+
+  it('second apply same sourceId replaces, list length 1', async () => {
+    const store = new ConnectedSourceStore();
+    await sourceInviteApplier.apply(AVA, store);
+    await sourceInviteApplier.apply({ ...AVA, displayName: 'Updated' }, store);
+    expect(await store.list()).toHaveLength(1);
+  });
+});

--- a/packages/mobile/src/install/applySourceInvite.ts
+++ b/packages/mobile/src/install/applySourceInvite.ts
@@ -1,0 +1,39 @@
+/**
+ * SOURCE_INVITE.md §8.2 — register metadata only; never writes SecureStore.
+ */
+
+import type { ISourceInvitePayload } from '@scholaracle/contracts';
+import {
+  ADAPTER_IDS,
+  buildCredentialKey,
+  type IConnectedSource,
+  type IConnectedSourceStore,
+} from '../sources/ConnectedSourceStore';
+import type { ISourceInviteApplier } from './types';
+
+export function sourceIdForInvite(payload: ISourceInvitePayload): string {
+  return `local-${payload.provider}-${payload.institutionExternalId}`;
+}
+
+export const sourceInviteApplier: ISourceInviteApplier = {
+  async apply(
+    payload: ISourceInvitePayload,
+    store: IConnectedSourceStore
+  ): Promise<IConnectedSource> {
+    const adapterId = ADAPTER_IDS[payload.provider] ?? payload.adapterId;
+    const credentialKey = buildCredentialKey(payload.provider, payload.portalBaseUrl);
+    const source: IConnectedSource = {
+      provider: payload.provider,
+      adapterId,
+      baseUrl: payload.portalBaseUrl,
+      sourceId: sourceIdForInvite(payload),
+      credentialKey,
+      studentExternalId: payload.studentExternalId,
+      institutionExternalId: payload.institutionExternalId,
+      studentId: payload.studentId,
+      adapterVersion: '0.1.0',
+    };
+    await store.upsert(source);
+    return source;
+  },
+};

--- a/packages/mobile/src/install/connectSourceInitialState.test.ts
+++ b/packages/mobile/src/install/connectSourceInitialState.test.ts
@@ -1,0 +1,34 @@
+/**
+ * SOURCE_INVITE.md §8.3
+ */
+
+import { SOURCE_INVITE_ADAPTER_IDS, type ISourceInvitePayload } from '@scholaracle/contracts';
+import { connectSourceInitialState } from './connectSourceInitialState';
+
+const AVA: ISourceInvitePayload = {
+  provider: 'skyward',
+  adapterId: SOURCE_INVITE_ADAPTER_IDS.skyward,
+  portalBaseUrl: 'https://skyward.iscorp.com',
+  displayName: 'Skyward Family Access (skyward.iscorp.com)',
+  studentId: 'stu-mongo-1',
+  studentExternalId: 'ava-lewis',
+  institutionExternalId: 'skyward.iscorp.com',
+};
+
+describe('connectSourceInitialState', () => {
+  it('no invite → step provider, unlocked', () => {
+    const state = connectSourceInitialState();
+    expect(state.step).toBe('provider');
+    expect(state.providerLocked).toBe(false);
+    expect(state.urlLocked).toBe(false);
+  });
+
+  it('Ava invite → credentials with locked iscorp URL', () => {
+    const state = connectSourceInitialState(AVA);
+    expect(state.step).toBe('credentials');
+    expect(state.portalUrl).toBe('https://skyward.iscorp.com');
+    expect(state.provider).toBe('skyward');
+    expect(state.providerLocked).toBe(true);
+    expect(state.urlLocked).toBe(true);
+  });
+});

--- a/packages/mobile/src/install/connectSourceInitialState.ts
+++ b/packages/mobile/src/install/connectSourceInitialState.ts
@@ -1,0 +1,27 @@
+/**
+ * SOURCE_INVITE.md §8.3
+ */
+
+import type { ISourceInvitePayload } from '@scholaracle/contracts';
+import type { IConnectSourceInitialState } from './types';
+
+export function connectSourceInitialState(
+  invite?: ISourceInvitePayload
+): IConnectSourceInitialState {
+  if (!invite) {
+    return {
+      step: 'provider',
+      provider: null,
+      portalUrl: '',
+      providerLocked: false,
+      urlLocked: false,
+    };
+  }
+  return {
+    step: 'credentials',
+    provider: invite.provider,
+    portalUrl: invite.portalBaseUrl,
+    providerLocked: true,
+    urlLocked: true,
+  };
+}

--- a/packages/mobile/src/install/handleInstallLink.test.ts
+++ b/packages/mobile/src/install/handleInstallLink.test.ts
@@ -1,0 +1,89 @@
+/**
+ * SOURCE_INVITE.md §8.1
+ */
+
+import { SOURCE_INVITE_ADAPTER_IDS, type ISourceInvitePayload } from '@scholaracle/contracts';
+import {
+  handleInstallLink,
+  INSTALL_LINK_EXPIRED_MESSAGE,
+  redeemPendingInstall,
+} from './handleInstallLink';
+import { installSourceLinkParser } from './installSourceDeepLink';
+import type { IPendingSourceInviteStore } from './types';
+
+const AVA_TOKEN = 'ab'.repeat(32);
+const AVA: ISourceInvitePayload = {
+  provider: 'skyward',
+  adapterId: SOURCE_INVITE_ADAPTER_IDS.skyward,
+  portalBaseUrl: 'https://skyward.iscorp.com',
+  displayName: 'Skyward Family Access (skyward.iscorp.com)',
+  studentId: 'stu-mongo-1',
+  studentExternalId: 'ava-lewis',
+  institutionExternalId: 'skyward.iscorp.com',
+};
+
+describe('handleInstallLink', () => {
+  it('saves pending token when logged out', async () => {
+    const pending: IPendingSourceInviteStore = {
+      save: jest.fn().mockResolvedValue(undefined),
+      take: jest.fn(),
+    };
+    const redeem = jest.fn();
+    await handleInstallLink(`scholarmancy://install-source?t=${AVA_TOKEN}`, {
+      parser: installSourceLinkParser,
+      pending,
+      redeem,
+      apply: { apply: jest.fn() },
+      isLoggedIn: false,
+      onApplied: jest.fn(),
+      onError: jest.fn(),
+    });
+    expect(pending.save).toHaveBeenCalledWith(AVA_TOKEN);
+    expect(redeem).not.toHaveBeenCalled();
+  });
+
+  it('redeems and applies when logged in', async () => {
+    const onApplied = jest.fn();
+    const apply = jest.fn().mockResolvedValue({ sourceId: 'local-skyward-skyward.iscorp.com' });
+    await handleInstallLink(`scholarmancy://install-source?t=${AVA_TOKEN}`, {
+      parser: installSourceLinkParser,
+      pending: { save: jest.fn(), take: jest.fn() },
+      redeem: jest.fn().mockResolvedValue(AVA),
+      apply: { apply },
+      isLoggedIn: true,
+      onApplied,
+      onError: jest.fn(),
+    });
+    expect(apply).toHaveBeenCalled();
+    expect(onApplied).toHaveBeenCalledWith(
+      AVA,
+      expect.objectContaining({ sourceId: 'local-skyward-skyward.iscorp.com' })
+    );
+  });
+
+  it('alerts generic expiry on redeem failure', async () => {
+    const onError = jest.fn();
+    await handleInstallLink(`scholarmancy://install-source?t=${AVA_TOKEN}`, {
+      parser: installSourceLinkParser,
+      pending: { save: jest.fn(), take: jest.fn() },
+      redeem: jest.fn().mockRejectedValue(new Error('nope')),
+      apply: { apply: jest.fn() },
+      isLoggedIn: true,
+      onApplied: jest.fn(),
+      onError,
+    });
+    expect(onError).toHaveBeenCalledWith(INSTALL_LINK_EXPIRED_MESSAGE);
+  });
+
+  it('redeemPendingInstall takes then redeems', async () => {
+    const onApplied = jest.fn();
+    await redeemPendingInstall({
+      pending: { save: jest.fn(), take: jest.fn().mockResolvedValue(AVA_TOKEN) },
+      redeem: jest.fn().mockResolvedValue(AVA),
+      apply: { apply: jest.fn().mockResolvedValue({}) },
+      onApplied,
+      onError: jest.fn(),
+    });
+    expect(onApplied).toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/install/handleInstallLink.ts
+++ b/packages/mobile/src/install/handleInstallLink.ts
@@ -1,0 +1,61 @@
+/**
+ * SOURCE_INVITE.md §8.1 — extracted from App.tsx so the handler is unit-tested.
+ */
+
+import type { ISourceInvitePayload } from '@scholaracle/contracts';
+import type { IConnectedSource } from '../sources/ConnectedSourceStore';
+import type {
+  IInstallSourceLinkParser,
+  IPendingSourceInviteStore,
+  ISourceInviteApplier,
+} from './types';
+import { connectedSourceStore } from '../sources/ConnectedSourceStore';
+
+export const INSTALL_LINK_EXPIRED_MESSAGE = 'This install link expired or is not for this account.';
+
+export interface IHandleInstallLinkDeps {
+  readonly parser: IInstallSourceLinkParser;
+  readonly pending: IPendingSourceInviteStore;
+  readonly redeem: (token: string) => Promise<ISourceInvitePayload>;
+  readonly apply: ISourceInviteApplier;
+  readonly isLoggedIn: boolean;
+  readonly onApplied: (payload: ISourceInvitePayload, source: IConnectedSource) => void;
+  readonly onError: (message: string) => void;
+}
+
+export async function handleInstallLink(
+  url: string | null | undefined,
+  deps: IHandleInstallLinkDeps
+): Promise<void> {
+  if (!deps.parser.isInstallSourceDeepLink(url)) return;
+  const token = deps.parser.parseInstallSourceToken(url);
+  if (!token) {
+    deps.onError(INSTALL_LINK_EXPIRED_MESSAGE);
+    return;
+  }
+  if (!deps.isLoggedIn) {
+    await deps.pending.save(token);
+    return;
+  }
+  try {
+    const payload = await deps.redeem(token);
+    const source = await deps.apply.apply(payload, connectedSourceStore);
+    deps.onApplied(payload, source);
+  } catch {
+    deps.onError(INSTALL_LINK_EXPIRED_MESSAGE);
+  }
+}
+
+export async function redeemPendingInstall(
+  deps: Omit<IHandleInstallLinkDeps, 'parser' | 'isLoggedIn'>
+): Promise<void> {
+  const token = await deps.pending.take();
+  if (!token) return;
+  try {
+    const payload = await deps.redeem(token);
+    const source = await deps.apply.apply(payload, connectedSourceStore);
+    deps.onApplied(payload, source);
+  } catch {
+    deps.onError(INSTALL_LINK_EXPIRED_MESSAGE);
+  }
+}

--- a/packages/mobile/src/install/installSourceDeepLink.test.ts
+++ b/packages/mobile/src/install/installSourceDeepLink.test.ts
@@ -1,0 +1,45 @@
+/**
+ * SOURCE_INVITE.md §8.1
+ */
+
+import { isInstallSourceDeepLink, parseInstallSourceToken } from './installSourceDeepLink';
+
+const AVA_TOKEN = 'ab'.repeat(32);
+
+describe('installSourceDeepLink', () => {
+  it.each([
+    [`scholarmancy://install-source?t=${AVA_TOKEN}`, AVA_TOKEN],
+    [`scholarmancy:install-source?t=${AVA_TOKEN}`, AVA_TOKEN],
+    [`scholarmancy:///install-source?t=${AVA_TOKEN}`, AVA_TOKEN],
+    [`  SCHOLARMANCY://install-source?t=${AVA_TOKEN}  `, AVA_TOKEN],
+    [`scholarmancy://install-source/?t=${AVA_TOKEN}`, AVA_TOKEN],
+  ])('parses token from %s', (url, expected) => {
+    expect(isInstallSourceDeepLink(url)).toBe(true);
+    expect(parseInstallSourceToken(url)).toBe(expected);
+  });
+
+  it.each([
+    ['scholarmancy://demo', null],
+    ['scholarmancy://diag', null],
+    [`https://api.example/install-source?t=${AVA_TOKEN}`, null],
+    ['scholarmancy://install-source', null],
+    ['scholarmancy://install-source?t=abc', null],
+    [`scholarmancy://install-source?t=${AVA_TOKEN}&password=x`, AVA_TOKEN],
+    [null, null],
+    [undefined, null],
+    ['not a url', null],
+  ])('%s -> token %s', (url, expected) => {
+    if (expected === null) {
+      if (typeof url === 'string' && url.startsWith('scholarmancy://install-source')) {
+        expect(isInstallSourceDeepLink(url)).toBe(true);
+      }
+      expect(parseInstallSourceToken(url)).toBeNull();
+    } else {
+      expect(parseInstallSourceToken(url)).toBe(expected);
+    }
+  });
+
+  it('does not throw on garbage', () => {
+    expect(parseInstallSourceToken('::::')).toBeNull();
+  });
+});

--- a/packages/mobile/src/install/installSourceDeepLink.ts
+++ b/packages/mobile/src/install/installSourceDeepLink.ts
@@ -1,0 +1,63 @@
+/**
+ * SOURCE_INVITE.md §8.1 — parse scholarmancy://install-source?t=
+ *
+ * Plain string operations, NOT the URL API. React Native's URL polyfill only
+ * understands http(s). See demoLogin.ts.
+ */
+
+import { sanitizeInstallToken } from '@scholaracle/contracts';
+import type { IInstallSourceLinkParser } from './types';
+
+const SCHEME_PREFIX = 'scholarmancy:';
+const INSTALL_PATH = 'install-source';
+
+function installSourceTarget(
+  url: string
+): { readonly path: string; readonly query: string } | null {
+  const normalized = url.trim();
+  const lower = normalized.toLowerCase();
+  if (!lower.startsWith(SCHEME_PREFIX)) return null;
+  const afterScheme = normalized.slice(SCHEME_PREFIX.length).replace(/^\/+/, '');
+  const qIdx = afterScheme.indexOf('?');
+  const hashIdx = afterScheme.indexOf('#');
+  let pathAndQuery = afterScheme;
+  if (hashIdx >= 0) pathAndQuery = afterScheme.slice(0, hashIdx);
+  const path = (qIdx >= 0 ? pathAndQuery.slice(0, qIdx) : pathAndQuery)
+    .replace(/\/+$/, '')
+    .toLowerCase();
+  const query = qIdx >= 0 ? pathAndQuery.slice(qIdx + 1) : '';
+  return { path, query };
+}
+
+function queryValue(query: string, key: string): string | null {
+  const parts = query.split('&');
+  for (const part of parts) {
+    const eq = part.indexOf('=');
+    const k = (eq >= 0 ? part.slice(0, eq) : part).toLowerCase();
+    if (k === key) return eq >= 0 ? part.slice(eq + 1) : '';
+  }
+  return null;
+}
+
+export const installSourceLinkParser: IInstallSourceLinkParser = {
+  isInstallSourceDeepLink(url: string | null | undefined): boolean {
+    if (!url) return false;
+    const parsed = installSourceTarget(url);
+    return parsed?.path === INSTALL_PATH;
+  },
+
+  parseInstallSourceToken(url: string | null | undefined): string | null {
+    if (!url) return null;
+    const parsed = installSourceTarget(url);
+    if (!parsed || parsed.path !== INSTALL_PATH) return null;
+    const raw = queryValue(parsed.query, 't');
+    if (raw === null) return null;
+    const token = sanitizeInstallToken(decodeURIComponent(raw));
+    return token === '' ? null : token;
+  },
+};
+
+export const isInstallSourceDeepLink =
+  installSourceLinkParser.isInstallSourceDeepLink.bind(installSourceLinkParser);
+export const parseInstallSourceToken =
+  installSourceLinkParser.parseInstallSourceToken.bind(installSourceLinkParser);

--- a/packages/mobile/src/install/pendingSourceInviteStore.test.ts
+++ b/packages/mobile/src/install/pendingSourceInviteStore.test.ts
@@ -1,0 +1,19 @@
+/**
+ * SOURCE_INVITE.md §8.1
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { PendingSourceInviteStore } from './pendingSourceInviteStore';
+
+describe('PendingSourceInviteStore', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('save then take returns token; take again is null', async () => {
+    const store = new PendingSourceInviteStore();
+    await store.save('ab'.repeat(32));
+    expect(await store.take()).toBe('ab'.repeat(32));
+    expect(await store.take()).toBeNull();
+  });
+});

--- a/packages/mobile/src/install/pendingSourceInviteStore.ts
+++ b/packages/mobile/src/install/pendingSourceInviteStore.ts
@@ -1,0 +1,22 @@
+/**
+ * SOURCE_INVITE.md §8.1 — stash token until login.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { IPendingSourceInviteStore } from './types';
+
+const KEY = 'slc_pending_source_invite';
+
+export class PendingSourceInviteStore implements IPendingSourceInviteStore {
+  async save(token: string): Promise<void> {
+    await AsyncStorage.setItem(KEY, token);
+  }
+
+  async take(): Promise<string | null> {
+    const value = await AsyncStorage.getItem(KEY);
+    if (value) await AsyncStorage.removeItem(KEY);
+    return value;
+  }
+}
+
+export const pendingSourceInviteStore = new PendingSourceInviteStore();

--- a/packages/mobile/src/install/types.ts
+++ b/packages/mobile/src/install/types.ts
@@ -1,0 +1,28 @@
+/**
+ * SOURCE_INVITE.md §4.4 — mobile install ISP types.
+ */
+
+import type { ISourceInvitePayload, SourceInviteProvider } from '@scholaracle/contracts';
+import type { IConnectedSource, IConnectedSourceStore } from '../sources/ConnectedSourceStore';
+
+export interface IInstallSourceLinkParser {
+  isInstallSourceDeepLink(url: string | null | undefined): boolean;
+  parseInstallSourceToken(url: string | null | undefined): string | null;
+}
+
+export interface ISourceInviteApplier {
+  apply(payload: ISourceInvitePayload, store: IConnectedSourceStore): Promise<IConnectedSource>;
+}
+
+export interface IPendingSourceInviteStore {
+  save(token: string): Promise<void>;
+  take(): Promise<string | null>;
+}
+
+export interface IConnectSourceInitialState {
+  readonly step: 'provider' | 'url' | 'credentials';
+  readonly provider: SourceInviteProvider | null;
+  readonly portalUrl: string;
+  readonly providerLocked: boolean;
+  readonly urlLocked: boolean;
+}

--- a/packages/mobile/src/scraper/SyncOrchestrator.test.ts
+++ b/packages/mobile/src/scraper/SyncOrchestrator.test.ts
@@ -1,27 +1,59 @@
 /**
- * SyncOrchestrator unit tests — FakePageDriver + mocked ISP slices.
+ * SyncOrchestrator unit tests — stub IScraperResolver (ISP). Package-level
+ * mocks of runCanvasRecipe cannot reach runClientScrape's internal imports.
  */
 
-import { FakePageDriver } from '@scholaracle/scraper-core';
+import type { ISlcDeltaOp } from '@scholaracle/contracts';
+import {
+  FakePageDriver,
+  type IScraperResolver,
+  type IScraperModule,
+} from '@scholaracle/scraper-core';
 import { runSyncPipeline, SyncError } from './SyncOrchestrator';
 import type { IEnvelopeUploader, IRunRecorder } from '../api/interfaces';
 
-jest.mock('@scholaracle/scraper-core', () => {
-  const actual = jest.requireActual('@scholaracle/scraper-core');
+const NOW = '2026-01-15T10:00:00.000Z';
+
+function courseOp(): ISlcDeltaOp {
   return {
-    ...actual,
-    runCanvasRecipe: jest.fn().mockResolvedValue({
-      user: 'Test Student',
-      courses: [],
-      toDoItems: [],
-      upcomingEvents: [],
-      announcements: [],
-      timestamp: new Date().toISOString(),
-    }),
-    transformCanvasExtract: jest.fn().mockReturnValue([]),
-    validateEnvelope: jest.fn().mockReturnValue({ passed: true, errorCount: 0, warnings: [] }),
+    op: 'upsert',
+    entity: 'course',
+    key: {
+      provider: 'canvas',
+      adapterId: 'com.instructure.canvas',
+      studentExternalId: 'stu-1',
+      institutionExternalId: 'school.instructure.com',
+      externalId: 'canvas-course-101',
+    },
+    observedAt: NOW,
+    record: { title: 'Algebra 1', teacherName: 'Chang', period: '4' },
   };
-});
+}
+
+function stubResolver(opts: {
+  scrape?: () => Promise<Record<string, unknown>>;
+  transform?: () => ISlcDeltaOp[];
+}): IScraperResolver {
+  const module: IScraperModule = {
+    metadata: {
+      id: 'canvas',
+      name: 'Canvas',
+      adapterId: 'com.instructure.canvas',
+      version: '0.1.0',
+      hosts: ['*.instructure.com'],
+      entities: ['course'],
+      entry: 'builtin:canvas',
+      publisher: 'scholaracle',
+    },
+    scrape: opts.scrape ?? (async () => ({ user: 'Test Student', courses: [], timestamp: NOW })),
+    transform: opts.transform ?? (() => [courseOp()]),
+  };
+  return {
+    async resolve() {
+      return { module, canRun: true, checkErrors: [] };
+    },
+  };
+}
 
 describe('runSyncPipeline', () => {
   const config = {
@@ -64,7 +96,9 @@ describe('runSyncPipeline', () => {
     const recorder = makeRecorder();
     const uploader = makeUploader();
     const driver = new FakePageDriver({ initialUrl: config.baseUrl });
-    await runSyncPipeline(driver, config, uploader, 'token', recorder);
+    await runSyncPipeline(driver, config, uploader, 'token', recorder, undefined, {
+      resolver: stubResolver({}),
+    });
     expect(recorder.starts).toBe(1);
     expect(recorder.successes).toBe(1);
     expect(uploader.uploadEnvelope).toHaveBeenCalled();
@@ -74,32 +108,50 @@ describe('runSyncPipeline', () => {
     const recorder = makeRecorder();
     const uploader = makeUploader(true);
     const driver = new FakePageDriver({ initialUrl: config.baseUrl });
-    await expect(runSyncPipeline(driver, config, uploader, 'token', recorder)).rejects.toThrow(
-      /Upload failed/
-    );
+    await expect(
+      runSyncPipeline(driver, config, uploader, 'token', recorder, undefined, {
+        resolver: stubResolver({}),
+      })
+    ).rejects.toThrow(/Upload failed/);
     expect(recorder.fails).toBe(1);
   });
 
-  it('should record failure and report when validation fails', async () => {
-    const { validateEnvelope } = require('@scholaracle/scraper-core');
-    validateEnvelope.mockReturnValueOnce({ passed: false, errorCount: 2, warnings: [] });
+  it('should record failure when validation fails', async () => {
     const recorder = makeRecorder();
     const uploader = makeUploader();
     const driver = new FakePageDriver({ initialUrl: config.baseUrl });
-    await expect(runSyncPipeline(driver, config, uploader, 'token', recorder)).rejects.toThrow(
-      /validation failed/
-    );
+    await expect(
+      runSyncPipeline(driver, config, uploader, 'token', recorder, undefined, {
+        resolver: stubResolver({
+          transform: () => [
+            {
+              op: 'upsert',
+              entity: 'assignment',
+              key: {
+                provider: 'canvas',
+                adapterId: 'com.instructure.canvas',
+                externalId: 'bad',
+              },
+              observedAt: NOW,
+              record: {},
+            },
+          ],
+        }),
+      })
+    ).rejects.toThrow(/validation failed/);
     expect(recorder.fails).toBe(1);
-    expect(uploader.reportRunFailure).toHaveBeenCalled();
   });
 
   describe('SyncError phases', () => {
     async function captureError(
       uploader: IEnvelopeUploader,
-      recorder: IRunRecorder
+      recorder: IRunRecorder,
+      resolver: IScraperResolver
     ): Promise<unknown> {
       const driver = new FakePageDriver({ initialUrl: config.baseUrl });
-      return runSyncPipeline(driver, config, uploader, 'token', recorder).then(
+      return runSyncPipeline(driver, config, uploader, 'token', recorder, undefined, {
+        resolver,
+      }).then(
         () => {
           throw new Error('expected pipeline to reject');
         },
@@ -108,10 +160,16 @@ describe('runSyncPipeline', () => {
     }
 
     it('should tag scrape failures as phase "portal" and preserve the cause', async () => {
-      const { runCanvasRecipe } = require('@scholaracle/scraper-core');
       const underlying = new Error('portal timed out');
-      runCanvasRecipe.mockRejectedValueOnce(underlying);
-      const err = await captureError(makeUploader(), makeRecorder());
+      const err = await captureError(
+        makeUploader(),
+        makeRecorder(),
+        stubResolver({
+          scrape: async () => {
+            throw underlying;
+          },
+        })
+      );
       expect(err).toBeInstanceOf(SyncError);
       expect((err as SyncError).phase).toBe('portal');
       expect((err as SyncError).message).toBe('portal timed out');
@@ -119,12 +177,16 @@ describe('runSyncPipeline', () => {
     });
 
     it('should tag transform failures as phase "local" and preserve the cause', async () => {
-      const { transformCanvasExtract } = require('@scholaracle/scraper-core');
       const underlying = new Error('bad extract shape');
-      transformCanvasExtract.mockImplementationOnce(() => {
-        throw underlying;
-      });
-      const err = await captureError(makeUploader(), makeRecorder());
+      const err = await captureError(
+        makeUploader(),
+        makeRecorder(),
+        stubResolver({
+          transform: () => {
+            throw underlying;
+          },
+        })
+      );
       expect(err).toBeInstanceOf(SyncError);
       expect((err as SyncError).phase).toBe('local');
       expect((err as SyncError).message).toBe('bad extract shape');
@@ -132,9 +194,25 @@ describe('runSyncPipeline', () => {
     });
 
     it('should tag validation failures as phase "local"', async () => {
-      const { validateEnvelope } = require('@scholaracle/scraper-core');
-      validateEnvelope.mockReturnValueOnce({ passed: false, errorCount: 3, warnings: [] });
-      const err = await captureError(makeUploader(), makeRecorder());
+      const err = await captureError(
+        makeUploader(),
+        makeRecorder(),
+        stubResolver({
+          transform: () => [
+            {
+              op: 'upsert',
+              entity: 'assignment',
+              key: {
+                provider: 'canvas',
+                adapterId: 'com.instructure.canvas',
+                externalId: 'bad',
+              },
+              observedAt: NOW,
+              record: {},
+            },
+          ],
+        })
+      );
       expect(err).toBeInstanceOf(SyncError);
       expect((err as SyncError).phase).toBe('local');
       expect((err as SyncError).message).toMatch(/validation failed/);
@@ -148,7 +226,7 @@ describe('runSyncPipeline', () => {
         }),
         reportRunFailure: jest.fn(async () => undefined),
       };
-      const err = await captureError(uploader, makeRecorder());
+      const err = await captureError(uploader, makeRecorder(), stubResolver({}));
       expect(err).toBeInstanceOf(SyncError);
       expect((err as SyncError).phase).toBe('upload');
       expect((err as SyncError).message).toBe('HTTP 503');
@@ -163,8 +241,6 @@ describe('runSyncPipeline', () => {
         events.push('startRun');
       }),
       addPhase: jest.fn(async (_runId: string, phase: { phase: string }) => {
-        // Resolve on a later tick so an un-awaited addPhase would land
-        // after the next pipeline step in the event log.
         await new Promise((resolve) => setTimeout(resolve, 2));
         events.push(`addPhase:${phase.phase}`);
       }),
@@ -179,10 +255,13 @@ describe('runSyncPipeline', () => {
       reportRunFailure: jest.fn(async () => undefined),
     };
     const driver = new FakePageDriver({ initialUrl: config.baseUrl });
-    await runSyncPipeline(driver, config, uploader, 'token', recorder);
+    await runSyncPipeline(driver, config, uploader, 'token', recorder, undefined, {
+      resolver: stubResolver({}),
+    });
     expect(events).toEqual([
       'startRun',
       'addPhase:extracting',
+      'addPhase:transforming',
       'addPhase:transforming',
       'addPhase:transforming',
       'addPhase:validating',

--- a/packages/mobile/src/scraper/SyncOrchestrator.ts
+++ b/packages/mobile/src/scraper/SyncOrchestrator.ts
@@ -1,67 +1,38 @@
 /**
- * SyncOrchestrator — on-device scrape → transform → validate → upload.
- * Depends on ISP slices (IEnvelopeUploader, IRunRecorder), not the concrete API client.
+ * SyncOrchestrator — thin host builder for the unified scrape pipeline.
+ *
+ * After calling authenticate() externally, callers pass a live IPageDriver
+ * to runSyncPipeline(). This delegates to runClientScrape() in scraper-core,
+ * removing the per-provider switch and centralizing the pipeline logic.
  */
 
-import * as Crypto from 'expo-crypto';
 import {
-  SLC_INGEST_SCHEMA_VERSION_V1,
-  type ISlcIngestEnvelopeV1,
-  type ISlcDeltaOp,
-} from '@scholaracle/contracts';
-import {
-  runCanvasRecipe,
-  runSkywardRecipe,
-  runAeriesRecipe,
-  transformCanvasExtract,
-  transformSkywardExtract,
-  transformAeriesExtract,
-  validateEnvelope,
-  type ICanvasBrowserExtract,
-  type ISkywardFullExtract,
-  type IAeriesFullExtract,
+  runClientScrape,
+  SCRAPER_CORE_PACKAGE_VERSION,
   type IPageDriver,
+  type IIngestUploader,
+  type SyncProgressCallback,
+  type IScraperResolver,
+  type IAIEnricher,
 } from '@scholaracle/scraper-core';
-import type { IEnvelopeUploader, IRunRecorder } from '../api/interfaces';
+import type { ISlcIngestEnvelopeV1 } from '@scholaracle/contracts';
+// Re-export pipeline types for existing callers
+export type {
+  SyncPhase,
+  SyncFailurePhase,
+  ISyncProgress,
+  SyncProgressCallback,
+} from '@scholaracle/scraper-core';
+export { SyncError } from '@scholaracle/scraper-core';
+import type { IEnvelopeUploader, IRunRecorder as IMobileRunRecorder } from '../api/interfaces';
+import type {
+  IRunRecorder,
+  IStartRunParams,
+  IPhaseRecord,
+  IRunResult,
+} from '@scholaracle/scraper-core';
 
-export type SyncPhase =
-  'idle' | 'extracting' | 'transforming' | 'validating' | 'uploading' | 'complete' | 'error';
-
-/** Where in the pipeline a sync failure originated. */
-export type SyncFailurePhase = 'portal' | 'upload' | 'local';
-
-/**
- * Typed pipeline failure. `phase` tells callers where it broke:
- *  - 'portal': scraping/extraction against the school portal (session issues live here)
- *  - 'local':  on-device transform/validation
- *  - 'upload': HTTP upload to Scholaracle
- * The underlying error is preserved in `cause`.
- */
-export class SyncError extends Error {
-  readonly phase: SyncFailurePhase;
-
-  constructor(message: string, phase: SyncFailurePhase, cause?: unknown) {
-    super(message);
-    this.name = 'SyncError';
-    this.phase = phase;
-    if (cause !== undefined) this.cause = cause;
-  }
-}
-
-function toSyncError(err: unknown, phase: SyncFailurePhase, fallbackMessage: string): SyncError {
-  if (err instanceof SyncError) return err;
-  const message = err instanceof Error ? err.message : fallbackMessage;
-  return new SyncError(message, phase, err);
-}
-
-export interface ISyncProgress {
-  readonly phase: SyncPhase;
-  readonly message: string;
-  readonly opCount?: number;
-}
-
-export type SyncProgressCallback = (progress: ISyncProgress) => void;
-
+// Exported for callers that inspect the progress shape
 export interface ISyncOrchestratorConfig {
   readonly provider: 'canvas' | 'skyward' | 'aeries';
   readonly adapterId: string;
@@ -73,195 +44,87 @@ export interface ISyncOrchestratorConfig {
   readonly coreVersion?: string;
 }
 
+/** Optional host slices. Production callers omit this; tests inject a stub resolver. */
+export interface ISyncPipelineOverrides {
+  readonly resolver?: IScraperResolver;
+  readonly enricher?: IAIEnricher;
+  readonly enricherTimeoutMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Adapters: mobile interfaces → scraper-core interfaces
+// ---------------------------------------------------------------------------
+
+function buildMobileUploader(uploader: IEnvelopeUploader, connectorToken: string): IIngestUploader {
+  return {
+    async upload(envelope: ISlcIngestEnvelopeV1): Promise<void> {
+      await uploader.uploadEnvelope(envelope, connectorToken);
+    },
+    async reportFailure(runId: string, sourceId: string, error: string): Promise<void> {
+      await uploader
+        .reportRunFailure({
+          runId,
+          sourceId,
+          connectorToken,
+          error,
+          clientMeta: { clientType: 'mobile' },
+        })
+        .catch(() => undefined);
+    },
+  };
+}
+
+function buildMobileRecorder(mobileRecorder: IMobileRunRecorder): IRunRecorder {
+  return {
+    async startRun(params: IStartRunParams): Promise<void> {
+      await mobileRecorder.startRun({
+        runId: params.runId,
+        provider: params.provider,
+        studentExternalId: params.studentExternalId,
+        adapterVersion: params.adapterVersion,
+        coreVersion: params.coreVersion,
+      });
+    },
+    async addPhase(runId: string, phase: IPhaseRecord): Promise<void> {
+      await mobileRecorder.addPhase(runId, phase);
+    },
+    async completeRun(runId: string, result: IRunResult): Promise<void> {
+      await mobileRecorder.completeRun(runId, result);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 export async function runSyncPipeline(
   driver: IPageDriver,
   config: ISyncOrchestratorConfig,
   uploader: IEnvelopeUploader,
   connectorToken: string,
-  recorder: IRunRecorder,
-  onProgress?: SyncProgressCallback
+  recorder: IMobileRunRecorder,
+  onProgress?: SyncProgressCallback,
+  overrides?: ISyncPipelineOverrides
 ): Promise<ISlcIngestEnvelopeV1> {
-  const runId = Crypto.randomUUID();
-  const coreVersion = config.coreVersion ?? '0.1.0';
-  const clientMeta = {
-    clientType: 'mobile',
-    coreVersion,
-    adapterVersion: config.adapterVersion,
-  };
-
-  await recorder.startRun({
-    runId,
-    provider: config.provider,
-    studentExternalId: config.studentExternalId,
-    adapterVersion: config.adapterVersion,
-    coreVersion,
-  });
-
-  const phaseStart = { current: Date.now() };
-  const emitPhase = async (
-    phase: SyncPhase,
-    message: string,
-    extra?: { opCount?: number }
-  ): Promise<void> => {
-    const now = Date.now();
-    await recorder.addPhase(runId, {
-      phase,
-      message,
-      timestamp: new Date().toISOString(),
-      durationMs: now - phaseStart.current,
-    });
-    phaseStart.current = now;
-    onProgress?.({ phase, message, ...extra });
-  };
-  const emitProgress = async (progress: ISyncProgress): Promise<void> => {
-    await emitPhase(progress.phase, progress.message, { opCount: progress.opCount });
-  };
-
-  const ctx = {
-    provider: config.provider,
-    adapterId: config.adapterId,
-    studentExternalId: config.studentExternalId,
-    institutionExternalId: config.institutionExternalId,
-  };
-
-  let ops: ISlcDeltaOp[];
-  try {
-    await emitPhase('extracting', 'Extracting data from portal...');
-    ops = await extractAndTransform(driver, config, ctx, emitProgress);
-  } catch (err: unknown) {
-    // extractAndTransform already tags portal vs local; anything else that
-    // escapes this block is treated as a portal-side extraction failure.
-    const syncErr = toSyncError(err, 'portal', 'Extract/transform failed');
-    await recorder.completeRun(runId, { status: 'failed', errorMessage: syncErr.message });
-    await uploader
-      .reportRunFailure({
-        runId,
-        sourceId: config.sourceId,
-        connectorToken,
-        error: syncErr.message,
-        clientMeta,
-      })
-      .catch(() => undefined);
-    throw syncErr;
-  }
-
-  await emitPhase('transforming', `Produced ${ops.length} operations`, { opCount: ops.length });
-  await emitPhase('validating', 'Validating envelope...');
-
-  const now = new Date().toISOString();
-  const envelope: ISlcIngestEnvelopeV1 = {
-    schemaVersion: SLC_INGEST_SCHEMA_VERSION_V1,
-    run: {
-      runId,
-      startedAt: now,
-      endedAt: new Date().toISOString(),
+  return runClientScrape({
+    driver,
+    config: {
       provider: config.provider,
       adapterId: config.adapterId,
       adapterVersion: config.adapterVersion,
-      mode: 'delta',
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      meta: clientMeta,
-    },
-    source: {
+      baseUrl: config.baseUrl,
       sourceId: config.sourceId,
-      displayName: `${config.provider} (mobile)`,
-      portalBaseUrl: config.baseUrl,
+      studentExternalId: config.studentExternalId,
+      institutionExternalId: config.institutionExternalId,
+      coreVersion: config.coreVersion ?? SCRAPER_CORE_PACKAGE_VERSION,
     },
-    ops,
-  };
-
-  const report = validateEnvelope(envelope);
-  if (!report.passed) {
-    const msg = `Envelope validation failed: ${report.errorCount} errors`;
-    await recorder.completeRun(runId, { status: 'failed', opCount: ops.length, errorMessage: msg });
-    await uploader
-      .reportRunFailure({
-        runId,
-        sourceId: config.sourceId,
-        connectorToken,
-        error: msg,
-        clientMeta,
-      })
-      .catch(() => undefined);
-    throw new SyncError(msg, 'local');
-  }
-
-  await emitPhase('uploading', 'Uploading to Scholaracle...');
-  try {
-    await uploader.uploadEnvelope(envelope, connectorToken);
-  } catch (err: unknown) {
-    const syncErr = toSyncError(err, 'upload', 'Upload failed');
-    await recorder.completeRun(runId, {
-      status: 'failed',
-      opCount: ops.length,
-      errorMessage: syncErr.message,
-    });
-    throw syncErr;
-  }
-
-  await recorder.completeRun(runId, { status: 'success', opCount: ops.length });
-  await emitPhase('complete', `Sync complete — ${ops.length} ops`, { opCount: ops.length });
-  return envelope;
-}
-
-/** Run a portal-facing step; failures become SyncError phase 'portal'. */
-async function runPortalStep<T>(step: () => Promise<T>): Promise<T> {
-  try {
-    return await step();
-  } catch (err: unknown) {
-    throw toSyncError(err, 'portal', 'Portal extraction failed');
-  }
-}
-
-/** Run an on-device step; failures become SyncError phase 'local'. */
-function runLocalStep<T>(step: () => T): T {
-  try {
-    return step();
-  } catch (err: unknown) {
-    throw toSyncError(err, 'local', 'Transform failed');
-  }
-}
-
-async function extractAndTransform(
-  driver: IPageDriver,
-  config: ISyncOrchestratorConfig,
-  ctx: {
-    provider: string;
-    adapterId: string;
-    studentExternalId: string;
-    institutionExternalId: string;
-  },
-  emit: (progress: ISyncProgress) => Promise<void>
-): Promise<ISlcDeltaOp[]> {
-  if (config.provider === 'canvas') {
-    const raw: ICanvasBrowserExtract = await runPortalStep(() =>
-      runCanvasRecipe(driver, config.baseUrl)
-    );
-    await emit({ phase: 'transforming', message: 'Converting data...' });
-    return runLocalStep(() => transformCanvasExtract(raw, ctx));
-  }
-  if (config.provider === 'skyward') {
-    const raw: ISkywardFullExtract = await runPortalStep(() =>
-      runSkywardRecipe(driver, config.baseUrl)
-    );
-    await emit({ phase: 'transforming', message: 'Converting data...' });
-    return runLocalStep(() => transformSkywardExtract(raw, ctx));
-  }
-  if (config.provider === 'aeries') {
-    const raw: IAeriesFullExtract = await runPortalStep(() =>
-      runAeriesRecipe(driver, config.baseUrl)
-    );
-    await emit({ phase: 'transforming', message: 'Converting data...' });
-    return runLocalStep(() => {
-      const filtered: IAeriesFullExtract =
-        config.studentExternalId === 'default'
-          ? raw
-          : {
-              ...raw,
-              students: raw.students.filter((s) => s.studentId === config.studentExternalId),
-            };
-      return transformAeriesExtract(filtered.students.length > 0 ? filtered : raw, ctx);
-    });
-  }
-  throw new SyncError(`Unknown provider: ${config.provider as string}`, 'local');
+    clientType: 'mobile',
+    uploader: buildMobileUploader(uploader, connectorToken),
+    recorder: buildMobileRecorder(recorder),
+    onProgress,
+    resolver: overrides?.resolver,
+    enricher: overrides?.enricher,
+    enricherTimeoutMs: overrides?.enricherTimeoutMs,
+  });
 }

--- a/packages/mobile/src/scraper/companion-e2e.test.ts
+++ b/packages/mobile/src/scraper/companion-e2e.test.ts
@@ -6,7 +6,13 @@
  */
 
 import type { ICanvasBrowserExtract } from '@scholaracle/scraper-core';
-import { FakePageDriver, validateEnvelope } from '@scholaracle/scraper-core';
+import {
+  FakePageDriver,
+  validateEnvelope,
+  transformCanvasExtract,
+  type IScraperResolver,
+  type IScraperModule,
+} from '@scholaracle/scraper-core';
 import { runSyncPipeline, type ISyncOrchestratorConfig } from './SyncOrchestrator';
 import type { IEnvelopeUploader, IRunRecorder } from '../api/interfaces';
 
@@ -53,15 +59,32 @@ const REALISTIC_EXTRACT: ICanvasBrowserExtract = {
   ],
 };
 
-jest.mock('@scholaracle/scraper-core', () => {
-  const actual = jest.requireActual(
-    '@scholaracle/scraper-core'
-  ) as typeof import('@scholaracle/scraper-core');
-  return {
-    ...actual,
-    runCanvasRecipe: jest.fn(async () => REALISTIC_EXTRACT),
+function canvasResolver(
+  scrape: () => Promise<ICanvasBrowserExtract>,
+  transform?: IScraperModule['transform']
+): IScraperResolver {
+  const module: IScraperModule = {
+    metadata: {
+      id: 'canvas',
+      name: 'Canvas',
+      adapterId: 'com.instructure.canvas',
+      version: '0.1.0',
+      hosts: ['*.instructure.com'],
+      entities: ['course', 'assignment'],
+      entry: 'builtin:canvas',
+      publisher: 'scholaracle',
+    },
+    scrape: async () => (await scrape()) as unknown as Record<string, unknown>,
+    transform:
+      transform ??
+      ((raw, ctx) => transformCanvasExtract(raw as unknown as ICanvasBrowserExtract, ctx)),
   };
-});
+  return {
+    async resolve() {
+      return { module, canRun: true, checkErrors: [] };
+    },
+  };
+}
 
 describe('Companion E2E: FakePageDriver → validate → mock ingest', () => {
   const config: ISyncOrchestratorConfig = {
@@ -128,7 +151,8 @@ describe('Companion E2E: FakePageDriver → validate → mock ingest', () => {
       recorder,
       (p) => {
         phases.push(p.phase);
-      }
+      },
+      { resolver: canvasResolver(async () => REALISTIC_EXTRACT) }
     );
 
     // Real validator (not mocked)
@@ -159,56 +183,33 @@ describe('Companion E2E: FakePageDriver → validate → mock ingest', () => {
   });
 
   it('should fail validation (real validator) when transform yields bad ops', async () => {
-    const scraperCore =
-      require('@scholaracle/scraper-core') as typeof import('@scholaracle/scraper-core');
-    (scraperCore.runCanvasRecipe as jest.Mock).mockResolvedValueOnce({
-      user: 'Broken',
-      courses: [
-        {
-          id: '',
-          name: '', // empty title → transform may still emit; force empty course id path
-          courseCode: '',
-          url: 'https://school.instructure.com/courses/x',
-          teachers: [],
-          assignments: [
-            { id: 'bad', name: '', dueDate: undefined, points: undefined, status: undefined },
-          ],
-          modules: [],
-          files: [],
-        },
-      ],
-      toDoItems: [],
-      upcomingEvents: [],
-      announcements: [],
-      timestamp: '2026-08-04T12:00:00.000Z',
-    } satisfies ICanvasBrowserExtract);
-
-    // Spy transform to return explicitly invalid ops for this case
-    const transformSpy = jest.spyOn(scraperCore, 'transformCanvasExtract').mockReturnValueOnce([
-      {
-        op: 'upsert',
-        entity: 'course',
-        key: {
-          provider: 'canvas',
-          adapterId: 'com.instructure.canvas',
-          externalId: 'c-1',
-        },
-        observedAt: '2026-08-04T12:00:00.000Z',
-        record: {}, // missing required title
-      },
-    ]);
-
     const recorder = makeRecorder();
     const uploader = makeUploader();
     const driver = new FakePageDriver({ initialUrl: config.baseUrl });
 
-    await expect(runSyncPipeline(driver, config, uploader, 'token', recorder)).rejects.toThrow(
-      /validation failed/
-    );
+    await expect(
+      runSyncPipeline(driver, config, uploader, 'token', recorder, undefined, {
+        resolver: canvasResolver(
+          async () => REALISTIC_EXTRACT,
+          () => [
+            {
+              op: 'upsert',
+              entity: 'course',
+              key: {
+                provider: 'canvas',
+                adapterId: 'com.instructure.canvas',
+                externalId: 'c-1',
+              },
+              observedAt: '2026-08-04T12:00:00.000Z',
+              record: {},
+            },
+          ]
+        ),
+      })
+    ).rejects.toThrow(/validation failed/);
 
     expect(recorder.fails).toBe(1);
     expect(uploader.uploadEnvelope).not.toHaveBeenCalled();
     expect(uploader.reportRunFailure).toHaveBeenCalled();
-    transformSpy.mockRestore();
   });
 });

--- a/packages/mobile/src/screens/ConnectSourceScreen.tsx
+++ b/packages/mobile/src/screens/ConnectSourceScreen.tsx
@@ -28,6 +28,8 @@ import {
 } from '../sources/ConnectedSourceStore';
 import { apiClient } from '../api/client';
 import { extractHostname } from '../utils/urlNormalize';
+import type { ISourceInvitePayload } from '@scholaracle/contracts';
+import { connectSourceInitialState } from '../install/connectSourceInitialState';
 
 type Provider = 'canvas' | 'skyward' | 'aeries';
 
@@ -70,6 +72,7 @@ interface ISavedCredential {
 interface IConnectSourceScreenProps {
   readonly studentExternalId?: string;
   readonly studentId?: string;
+  readonly invite?: ISourceInvitePayload;
   onConnected(): void;
   onCancel(): void;
 }
@@ -77,12 +80,16 @@ interface IConnectSourceScreenProps {
 export function ConnectSourceScreen({
   studentExternalId,
   studentId,
+  invite,
   onConnected,
   onCancel,
 }: IConnectSourceScreenProps): React.ReactElement {
-  const [step, setStep] = useState<'provider' | 'url' | 'credentials'>('provider');
-  const [selectedProvider, setSelectedProvider] = useState<IProviderInfo | null>(null);
-  const [portalUrl, setPortalUrl] = useState('');
+  const initial = connectSourceInitialState(invite);
+  const [step, setStep] = useState<'provider' | 'url' | 'credentials'>(initial.step);
+  const [selectedProvider, setSelectedProvider] = useState<IProviderInfo | null>(
+    () => PROVIDERS.find((p) => p.id === initial.provider) ?? null
+  );
+  const [portalUrl, setPortalUrl] = useState(initial.portalUrl);
   const [urlError, setUrlError] = useState<string | null>(null);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
@@ -140,9 +147,9 @@ export function ConnectSourceScreen({
         baseUrl: portalUrl,
         sourceId,
         credentialKey: key,
-        studentExternalId: studentExternalId ?? 'default',
+        studentExternalId: invite?.studentExternalId ?? studentExternalId ?? 'default',
         institutionExternalId,
-        studentId,
+        studentId: invite?.studentId ?? studentId,
         adapterVersion: '0.1.0',
       });
 
@@ -232,6 +239,7 @@ export function ConnectSourceScreen({
       {step === 'credentials' && selectedProvider && (
         <View>
           <Text style={styles.stepTitle}>Sign in to {selectedProvider.name}</Text>
+          {initial.urlLocked ? <Text style={styles.stepHint}>{portalUrl}</Text> : null}
           <View style={styles.securityBadge}>
             <Text style={styles.securityText}>
               🔒 Your credentials are stored only on this device — never sent to our servers.
@@ -273,9 +281,11 @@ export function ConnectSourceScreen({
               <Text style={styles.buttonText}>Save &amp; Connect</Text>
             )}
           </TouchableOpacity>
-          <TouchableOpacity style={styles.back} onPress={() => setStep('url')}>
-            <Text style={styles.backText}>← Back</Text>
-          </TouchableOpacity>
+          {initial.urlLocked ? null : (
+            <TouchableOpacity style={styles.back} onPress={() => setStep('url')}>
+              <Text style={styles.backText}>← Back</Text>
+            </TouchableOpacity>
+          )}
         </View>
       )}
     </ScrollView>

--- a/packages/scraper-core/package.json
+++ b/packages/scraper-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scholaracle/scraper-core",
   "version": "0.1.0",
-  "description": "Runtime-agnostic scraper core: extractors, recipes, transformers, and validator shared across CLI, server workers, mobile app, and browser extension",
+  "description": "Runtime-agnostic scraper core: extractors, recipes, transformers, and validator shared across local CLI, mobile app, and browser extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/scraper-core/src/extractors/canvas/canvas-extractors.ts
+++ b/packages/scraper-core/src/extractors/canvas/canvas-extractors.ts
@@ -43,13 +43,7 @@ export interface ICanvasBrowserAssignment {
 export interface ICanvasModuleItem {
   readonly title: string;
   readonly type:
-    | 'Assignment'
-    | 'File'
-    | 'Page'
-    | 'Discussion'
-    | 'ExternalUrl'
-    | 'ExternalTool'
-    | 'SubHeader';
+    'Assignment' | 'File' | 'Page' | 'Discussion' | 'ExternalUrl' | 'ExternalTool' | 'SubHeader';
   readonly contentId?: string;
   readonly position: number;
 }
@@ -77,6 +71,7 @@ export interface ICanvasBrowserAnnouncement {
   readonly title: string;
   readonly course: string;
   readonly date?: string;
+  readonly body?: string;
 }
 
 export interface ICanvasBrowserCourse {

--- a/packages/scraper-core/src/extractors/skyward/skyward-extractors.test.ts
+++ b/packages/scraper-core/src/extractors/skyward/skyward-extractors.test.ts
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Skyward extractor tests — driver-contract: extractSkywardCourseAssignments
+ * must accept a SINGLE options object (ISP: narrow args, no positional multi-arg).
+ */
+
+import { extractSkywardCourseAssignments } from './skyward-extractors';
+
+describe('driver-contract — extractSkywardCourseAssignments', () => {
+  it('accepts a single options object (not two positional strings)', () => {
+    // If the function still has two positional params, .length === 2 and this test fails.
+    expect(extractSkywardCourseAssignments.length).toBe(1);
+  });
+
+  it('returns an empty array when document has no #gradeInfoDialog', () => {
+    // Running pure in Node (no DOM) — the function should degrade gracefully.
+    const result = extractSkywardCourseAssignments({ courseName: 'ALGEBRA', coursePeriod: '1' });
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/scraper-core/src/extractors/skyward/skyward-extractors.ts
+++ b/packages/scraper-core/src/extractors/skyward/skyward-extractors.ts
@@ -100,10 +100,10 @@ export function extractSkywardSchoolName(): string {
 }
 
 /** Extracts assignments from the Skyward gradeInfoDialog for a specific course. */
-export function extractSkywardCourseAssignments(
-  courseName: string,
-  coursePeriod: string
-): Array<{
+export function extractSkywardCourseAssignments(opts: {
+  courseName: string;
+  coursePeriod: string;
+}): Array<{
   title: string;
   course: string;
   period: string;
@@ -114,6 +114,7 @@ export function extractSkywardCourseAssignments(
   grade: string;
   status: 'graded' | 'missing' | 'late' | 'unknown';
 }> {
+  const { courseName, coursePeriod } = opts;
   const dialog = document.querySelector('#gradeInfoDialog');
   if (!dialog) return [];
 

--- a/packages/scraper-core/src/index.ts
+++ b/packages/scraper-core/src/index.ts
@@ -5,7 +5,7 @@
  * extractors, per-platform recipes, transformers, and envelope validator.
  *
  * Consumed by:
- *   - @scholaracle/scraper-playwright   (CLI + server workers)
+ *   - @scholaracle/scraper-playwright   (local CLI — runs on the user's machine)
  *   - packages/mobile                   (Expo/React Native WebView driver)
  *   - packages/extension                (Chrome/Edge MV3 content script driver)
  */
@@ -61,6 +61,33 @@ export type {
   IValidationCheck,
   IOpValidationResult,
 } from './validator/validator';
+
+// Unified client pipeline: runClientScrape, IClientScrapeHost, IIngestUploader, etc.
+export type {
+  SyncPhase,
+  ISyncProgress,
+  SyncProgressCallback,
+  SyncFailurePhase,
+  ClientType,
+  IClientScrapeConfig,
+  IIngestUploader,
+  IAssetHost,
+  IAIEnricher,
+  IStartRunParams,
+  IPhaseRecord,
+  IRunResult,
+  IRunRecorder,
+  IClientScrapeHost,
+} from './pipeline';
+export {
+  SyncError,
+  runClientScrape,
+  buildClientScrapeConfig,
+  JoinGapEnricher,
+  applyEnrichersFailOpen,
+  sanitizeEnrichedOps,
+  DEFAULT_ENRICHER_TIMEOUT_MS,
+} from './pipeline';
 
 // Community Scraper Platform (CSP-1): manifest + module contract + resolvers
 export type {

--- a/packages/scraper-core/src/pipeline/enrichment.test.ts
+++ b/packages/scraper-core/src/pipeline/enrichment.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Join-gap enricher + fail-open sanitizer — TDD.
+ *
+ * AI (and the deterministic JoinGapEnricher) may only fill empty allowlisted
+ * FKs using IDs that already exist in the op set. Anything else is discarded.
+ */
+
+import type { ISlcDeltaOp } from '@scholaracle/contracts';
+import {
+  JoinGapEnricher,
+  applyEnrichersFailOpen,
+  sanitizeEnrichedOps,
+  DEFAULT_ENRICHER_TIMEOUT_MS,
+} from './enrichment';
+import type { IAIEnricher } from './types';
+
+const NOW = '2026-01-15T10:00:00.000Z';
+
+function op(
+  entity: ISlcDeltaOp['entity'],
+  externalId: string,
+  record: Record<string, unknown>,
+  extraKey?: { courseExternalId?: string }
+): ISlcDeltaOp {
+  return {
+    op: 'upsert',
+    entity,
+    key: {
+      provider: 'skyward',
+      adapterId: 'com.skyward.grade',
+      studentExternalId: 'stu-1',
+      institutionExternalId: 'inst-1',
+      externalId,
+      ...(extraKey?.courseExternalId ? { courseExternalId: extraKey.courseExternalId } : {}),
+    },
+    observedAt: NOW,
+    record,
+  };
+}
+
+const algebra = op('course', 'skyward-course-A1', {
+  title: 'ALGEBRA 1',
+  period: '1',
+  teacherName: 'Smith',
+});
+const english = op('course', 'skyward-course-E2', {
+  title: 'ENGLISH 2',
+  period: '2',
+  teacherName: 'Jones',
+});
+const hw3 = op(
+  'assignment',
+  'skyward-assign-1-hw-3',
+  { title: 'HW 3', courseExternalId: 'skyward-course-A1' },
+  { courseExternalId: 'skyward-course-A1' }
+);
+
+describe('sanitizeEnrichedOps', () => {
+  it('rejects a different op count (enricher must not add or drop ops)', () => {
+    const original = [algebra];
+    const warnings: string[] = [];
+    const result = sanitizeEnrichedOps(original, [algebra, english], (m) => warnings.push(m));
+    expect(result).toBe(original);
+    expect(warnings[0]).toMatch(/count/i);
+  });
+
+  it('rejects a changed key.externalId', () => {
+    const original = [algebra];
+    const mutated = [{ ...algebra, key: { ...algebra.key, externalId: 'invented-id' } }];
+    const result = sanitizeEnrichedOps(original, mutated);
+    expect(result[0]?.key.externalId).toBe('skyward-course-A1');
+  });
+
+  it('rejects filling courseExternalId with an id not in the envelope', () => {
+    const attendance = op('attendanceEvent', 'att-1', {
+      date: '2026-01-10',
+      status: 'present',
+      periodName: '1',
+    });
+    const original = [algebra, attendance];
+    const mutated = [
+      algebra,
+      {
+        ...attendance,
+        record: { ...attendance.record, courseExternalId: 'skyward-course-NOPE' },
+      },
+    ];
+    const result = sanitizeEnrichedOps(original, mutated);
+    expect(result[1]?.record?.['courseExternalId']).toBeUndefined();
+  });
+
+  it('keeps a fill of an empty courseExternalId that matches an existing course', () => {
+    const attendance = op('attendanceEvent', 'att-1', {
+      date: '2026-01-10',
+      status: 'present',
+      periodName: '1',
+    });
+    const original = [algebra, attendance];
+    const mutated = [
+      algebra,
+      {
+        ...attendance,
+        key: { ...attendance.key, courseExternalId: 'skyward-course-A1' },
+        record: { ...attendance.record, courseExternalId: 'skyward-course-A1' },
+      },
+    ];
+    const result = sanitizeEnrichedOps(original, mutated);
+    expect(result[1]?.record?.['courseExternalId']).toBe('skyward-course-A1');
+    expect(result[1]?.key.courseExternalId).toBe('skyward-course-A1');
+  });
+
+  it('does not overwrite a non-empty courseExternalId', () => {
+    const attendance = op('attendanceEvent', 'att-1', {
+      date: '2026-01-10',
+      status: 'present',
+      courseExternalId: 'skyward-course-E2',
+    });
+    const original = [algebra, english, attendance];
+    const mutated = [
+      algebra,
+      english,
+      { ...attendance, record: { ...attendance.record, courseExternalId: 'skyward-course-A1' } },
+    ];
+    const result = sanitizeEnrichedOps(original, mutated);
+    expect(result[2]?.record?.['courseExternalId']).toBe('skyward-course-E2');
+  });
+});
+
+describe('JoinGapEnricher', () => {
+  const enricher = new JoinGapEnricher();
+
+  it('fills attendance courseExternalId from a unique period match', async () => {
+    const attendance = op('attendanceEvent', 'att-1', {
+      date: '2026-01-10',
+      status: 'present',
+      periodName: '1',
+      courseName: '',
+    });
+    const ops = await enricher.enrich({}, [algebra, english, attendance]);
+    expect(ops[2]?.record?.['courseExternalId']).toBe('skyward-course-A1');
+    expect(ops[2]?.key.courseExternalId).toBe('skyward-course-A1');
+    expect(ops[2]?.record?.['courseName']).toBe('ALGEBRA 1');
+  });
+
+  it('fills attendance courseExternalId from a unique normalized course name', async () => {
+    const attendance = op('attendanceEvent', 'att-1', {
+      date: '2026-01-10',
+      status: 'present',
+      courseName: 'Algebra 1',
+    });
+    const ops = await enricher.enrich({}, [algebra, english, attendance]);
+    expect(ops[2]?.record?.['courseExternalId']).toBe('skyward-course-A1');
+  });
+
+  it('does not fill when two courses share the same period', async () => {
+    const otherPeriod1 = op('course', 'skyward-course-B9', {
+      title: 'BAND',
+      period: '1',
+      teacherName: 'Lee',
+    });
+    const attendance = op('attendanceEvent', 'att-1', {
+      date: '2026-01-10',
+      status: 'present',
+      periodName: '1',
+    });
+    const ops = await enricher.enrich({}, [algebra, otherPeriod1, attendance]);
+    expect(ops[2]?.record?.['courseExternalId']).toBeUndefined();
+  });
+
+  it('links a message to an assignment on unique title match', async () => {
+    const msg = op('message', 'msg-1', {
+      subject: 'HW 3 reminder',
+      body: 'Please finish HW 3 tonight',
+      senderName: 'Canvas',
+    });
+    const ops = await enricher.enrich({}, [algebra, hw3, msg]);
+    expect(ops[2]?.record?.['assignmentExternalId']).toBe('skyward-assign-1-hw-3');
+  });
+
+  it('does not link a message when two assignments match the title', async () => {
+    const hw3b = op(
+      'assignment',
+      'skyward-assign-2-hw-3',
+      { title: 'HW 3', courseExternalId: 'skyward-course-E2' },
+      { courseExternalId: 'skyward-course-E2' }
+    );
+    const msg = op('message', 'msg-1', { subject: 'HW 3', body: 'HW 3' });
+    const ops = await enricher.enrich({}, [algebra, english, hw3, hw3b, msg]);
+    expect(ops[4]?.record?.['assignmentExternalId']).toBeUndefined();
+  });
+
+  it('links courseMaterial to an assignment on unique title co-occurrence', async () => {
+    const material = op(
+      'courseMaterial',
+      'file-1',
+      { title: 'HW 3 worksheet.pdf', courseExternalId: 'skyward-course-A1', type: 'document' },
+      { courseExternalId: 'skyward-course-A1' }
+    );
+    const ops = await enricher.enrich({}, [algebra, hw3, material]);
+    expect(ops[2]?.record?.['assignmentExternalId']).toBe('skyward-assign-1-hw-3');
+  });
+
+  it('fills assignment courseExternalId from unique course title when missing', async () => {
+    const orphan = op('assignment', 'assign-orphan', { title: 'Quiz', courseName: 'ALGEBRA 1' });
+    const ops = await enricher.enrich({}, [algebra, english, orphan]);
+    expect(ops[2]?.record?.['courseExternalId']).toBe('skyward-course-A1');
+    expect(ops[2]?.key.courseExternalId).toBe('skyward-course-A1');
+  });
+
+  it('never invents an externalId that was not already in the op set', async () => {
+    const attendance = op('attendanceEvent', 'att-1', {
+      date: '2026-01-10',
+      status: 'present',
+      periodName: '9',
+      courseName: 'Not A Real Class',
+    });
+    const ops = await enricher.enrich({}, [algebra, attendance]);
+    const ids = ops.map((o) => o.key.externalId);
+    expect(ids).toEqual(['skyward-course-A1', 'att-1']);
+    expect(ops[1]?.record?.['courseExternalId']).toBeUndefined();
+  });
+});
+
+describe('applyEnrichersFailOpen', () => {
+  const attendance = op('attendanceEvent', 'att-1', {
+    date: '2026-01-10',
+    status: 'present',
+    periodName: '1',
+  });
+  const baseOps = [algebra, attendance];
+
+  it('returns original ops when the enricher throws', async () => {
+    const boom: IAIEnricher = {
+      async enrich() {
+        throw new Error('model down');
+      },
+    };
+    const warnings: string[] = [];
+    const result = await applyEnrichersFailOpen({
+      enrichers: [boom],
+      rawExtract: {},
+      ops: baseOps,
+      onWarning: (m) => warnings.push(m),
+    });
+    expect(result.ops).toBe(baseOps);
+    expect(result.failed).toBe(true);
+    expect(warnings[0]).toMatch(/model down/);
+  });
+
+  it('returns original ops when the enricher times out', async () => {
+    const hung: IAIEnricher = {
+      enrich: () => new Promise(() => undefined),
+    };
+    const result = await applyEnrichersFailOpen({
+      enrichers: [hung],
+      rawExtract: {},
+      ops: baseOps,
+      timeoutMs: 20,
+    });
+    expect(result.ops).toBe(baseOps);
+    expect(result.failed).toBe(true);
+  });
+
+  it('discards illegal host patches and keeps prior legal fills', async () => {
+    const evil: IAIEnricher = {
+      async enrich(_raw: Record<string, unknown>, ops: ISlcDeltaOp[]): Promise<ISlcDeltaOp[]> {
+        return ops.map((o, i) => (i === 0 ? { ...o, key: { ...o.key, externalId: 'hacked' } } : o));
+      },
+    };
+    const result = await applyEnrichersFailOpen({
+      enrichers: [new JoinGapEnricher(), evil],
+      rawExtract: {},
+      ops: baseOps,
+    });
+    expect(result.ops[0]?.key.externalId).toBe('skyward-course-A1');
+    expect(result.ops[1]?.record?.['courseExternalId']).toBe('skyward-course-A1');
+  });
+
+  it('exposes a finite default timeout', () => {
+    expect(DEFAULT_ENRICHER_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(DEFAULT_ENRICHER_TIMEOUT_MS).toBeLessThanOrEqual(8000);
+  });
+});

--- a/packages/scraper-core/src/pipeline/enrichment.ts
+++ b/packages/scraper-core/src/pipeline/enrichment.ts
@@ -1,0 +1,361 @@
+/**
+ * Deterministic join-gap enrichment + fail-open sanitizer.
+ *
+ * Transformers remain the source of truth. This layer may only fill *empty*
+ * allowlisted FK/display fields using ids that already exist in the op set.
+ * It never invents entities, never rewrites native ids, never drops ops.
+ */
+
+import type { ISlcDeltaOp } from '@scholaracle/contracts';
+import type { IAIEnricher } from './types';
+
+export const DEFAULT_ENRICHER_TIMEOUT_MS = 8000;
+
+const ALLOWED_RECORD_FIELDS = ['courseExternalId', 'assignmentExternalId', 'courseName'] as const;
+type AllowedRecordField = (typeof ALLOWED_RECORD_FIELDS)[number];
+
+export interface IApplyEnrichersResult {
+  readonly ops: ISlcDeltaOp[];
+  readonly patchCount: number;
+  readonly failed: boolean;
+}
+
+export interface IApplyEnrichersParams {
+  readonly enrichers: readonly IAIEnricher[];
+  readonly rawExtract: Record<string, unknown>;
+  readonly ops: ISlcDeltaOp[];
+  readonly timeoutMs?: number;
+  readonly onWarning?: (message: string) => void;
+}
+
+function isEmpty(value: unknown): boolean {
+  return (
+    value === undefined || value === null || (typeof value === 'string' && value.trim() === '')
+  );
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function recordOf(op: ISlcDeltaOp): Record<string, unknown> {
+  return op.record ?? {};
+}
+
+function uniqueMap(pairs: ReadonlyArray<readonly [string, string]>): Map<string, string> {
+  const buckets = new Map<string, string[]>();
+  for (const [key, value] of pairs) {
+    if (!key) continue;
+    const list = buckets.get(key) ?? [];
+    if (!list.includes(value)) list.push(value);
+    buckets.set(key, list);
+  }
+  const unique = new Map<string, string>();
+  for (const [key, values] of buckets) {
+    if (values.length === 1 && values[0]) unique.set(key, values[0]);
+  }
+  return unique;
+}
+
+function courseIdsIn(ops: readonly ISlcDeltaOp[]): Set<string> {
+  const ids = new Set<string>();
+  for (const item of ops) {
+    if (item.op === 'upsert' && item.entity === 'course') ids.add(item.key.externalId);
+  }
+  return ids;
+}
+
+function assignmentIdsIn(ops: readonly ISlcDeltaOp[]): Set<string> {
+  const ids = new Set<string>();
+  for (const item of ops) {
+    if (item.op === 'upsert' && item.entity === 'assignment') ids.add(item.key.externalId);
+  }
+  return ids;
+}
+
+function identityKey(op: ISlcDeltaOp): string {
+  return `${op.op}|${op.entity}|${op.key.provider}|${op.key.adapterId}|${op.key.externalId}`;
+}
+
+/**
+ * Defense in depth: take a candidate op list and keep only allowlisted fills
+ * of previously empty fields, and only when FKs point at ids in `original`.
+ */
+export function sanitizeEnrichedOps(
+  original: readonly ISlcDeltaOp[],
+  candidate: readonly ISlcDeltaOp[],
+  onWarning?: (message: string) => void
+): ISlcDeltaOp[] {
+  if (candidate.length !== original.length) {
+    onWarning?.(`enricher changed op count (${original.length} → ${candidate.length}); discarded`);
+    return original as ISlcDeltaOp[];
+  }
+
+  const courses = courseIdsIn(original);
+  const assignments = assignmentIdsIn(original);
+  const next: ISlcDeltaOp[] = [];
+
+  for (let i = 0; i < original.length; i++) {
+    const before = original[i]!;
+    const after = candidate[i]!;
+    if (identityKey(before) !== identityKey(after)) {
+      next.push(before);
+      continue;
+    }
+
+    const beforeRec = recordOf(before);
+    const afterRec = recordOf(after);
+    const patched: Record<string, unknown> = { ...beforeRec };
+    let changed = false;
+
+    for (const field of ALLOWED_RECORD_FIELDS) {
+      if (!isEmpty(beforeRec[field])) continue;
+      const proposed = asNonEmptyString(afterRec[field]);
+      if (!proposed) continue;
+      if (field === 'courseExternalId' && courses.size > 0 && !courses.has(proposed)) continue;
+      if (field === 'assignmentExternalId' && assignments.size > 0 && !assignments.has(proposed)) {
+        continue;
+      }
+      patched[field] = proposed;
+      changed = true;
+    }
+
+    let nextKey = before.key;
+    if (isEmpty(before.key.courseExternalId)) {
+      const proposedKey =
+        asNonEmptyString(after.key.courseExternalId) ??
+        asNonEmptyString(patched['courseExternalId']);
+      if (proposedKey && (courses.size === 0 || courses.has(proposedKey))) {
+        nextKey = { ...before.key, courseExternalId: proposedKey };
+        if (isEmpty(patched['courseExternalId'])) {
+          patched['courseExternalId'] = proposedKey;
+        }
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      next.push(before);
+      continue;
+    }
+    next.push({ ...before, key: nextKey, record: patched });
+  }
+
+  return next;
+}
+
+function countPatches(original: readonly ISlcDeltaOp[], next: readonly ISlcDeltaOp[]): number {
+  let count = 0;
+  for (let i = 0; i < original.length; i++) {
+    const before = original[i];
+    const after = next[i];
+    if (!before || !after) continue;
+    const beforeRec = recordOf(before);
+    const afterRec = recordOf(after);
+    for (const field of ALLOWED_RECORD_FIELDS) {
+      if (asNonEmptyString(beforeRec[field]) !== asNonEmptyString(afterRec[field])) count += 1;
+    }
+    if (before.key.courseExternalId !== after.key.courseExternalId) count += 1;
+  }
+  return count;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`enricher timed out after ${timeoutMs}ms`)),
+          timeoutMs
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+export async function applyEnrichersFailOpen(
+  params: IApplyEnrichersParams
+): Promise<IApplyEnrichersResult> {
+  const timeoutMs = params.timeoutMs ?? DEFAULT_ENRICHER_TIMEOUT_MS;
+  let ops = params.ops;
+  let failed = false;
+
+  for (const enricher of params.enrichers) {
+    try {
+      const candidate = await withTimeout(enricher.enrich(params.rawExtract, ops), timeoutMs);
+      if (!Array.isArray(candidate)) {
+        failed = true;
+        params.onWarning?.('enricher returned a non-array; discarded');
+        continue;
+      }
+      ops = sanitizeEnrichedOps(ops, candidate, params.onWarning);
+    } catch (err: unknown) {
+      failed = true;
+      const message = err instanceof Error ? err.message : String(err);
+      params.onWarning?.(message);
+    }
+  }
+
+  return { ops, patchCount: countPatches(params.ops, ops), failed };
+}
+
+interface ICourseIndexEntry {
+  readonly externalId: string;
+  readonly title: string;
+  readonly period: string;
+}
+
+interface IAssignmentIndexEntry {
+  readonly externalId: string;
+  readonly title: string;
+  readonly courseExternalId?: string;
+}
+
+function patchOp(
+  item: ISlcDeltaOp,
+  recordPatch: Partial<Record<AllowedRecordField, string>>
+): ISlcDeltaOp {
+  const rec = { ...recordOf(item) };
+  for (const [field, value] of Object.entries(recordPatch) as Array<[AllowedRecordField, string]>) {
+    if (!isEmpty(rec[field])) continue;
+    rec[field] = value;
+  }
+  const courseId = asNonEmptyString(rec['courseExternalId']);
+  const nextKey =
+    isEmpty(item.key.courseExternalId) && courseId
+      ? { ...item.key, courseExternalId: courseId }
+      : item.key;
+  return { ...item, key: nextKey, record: rec };
+}
+
+function matchAssignmentId(
+  haystack: string,
+  assignments: readonly IAssignmentIndexEntry[],
+  preferCourseId?: string
+): string | undefined {
+  const hay = normalizeName(haystack);
+  if (hay.length < 4) return undefined;
+
+  const collect = (pool: readonly IAssignmentIndexEntry[]): string[] => {
+    const hits: string[] = [];
+    for (const assignment of pool) {
+      const title = normalizeName(assignment.title);
+      if (title.length < 4) continue;
+      if (hay === title || hay.includes(title)) hits.push(assignment.externalId);
+    }
+    return [...new Set(hits)];
+  };
+
+  if (preferCourseId) {
+    const scoped = collect(assignments.filter((a) => a.courseExternalId === preferCourseId));
+    if (scoped.length === 1) return scoped[0];
+  }
+  const global = collect(assignments);
+  return global.length === 1 ? global[0] : undefined;
+}
+
+/**
+ * Deterministic, no-LLM enricher. Safe to run on every client by default.
+ */
+export class JoinGapEnricher implements IAIEnricher {
+  async enrich(_rawExtract: Record<string, unknown>, ops: ISlcDeltaOp[]): Promise<ISlcDeltaOp[]> {
+    const courses: ICourseIndexEntry[] = [];
+    const assignments: IAssignmentIndexEntry[] = [];
+
+    for (const item of ops) {
+      if (item.op !== 'upsert') continue;
+      const rec = recordOf(item);
+      if (item.entity === 'course') {
+        courses.push({
+          externalId: item.key.externalId,
+          title: asNonEmptyString(rec['title']) ?? '',
+          period: asNonEmptyString(rec['period']) ?? '',
+        });
+      }
+      if (item.entity === 'assignment') {
+        assignments.push({
+          externalId: item.key.externalId,
+          title: asNonEmptyString(rec['title']) ?? '',
+          courseExternalId:
+            asNonEmptyString(item.key.courseExternalId) ??
+            asNonEmptyString(rec['courseExternalId']),
+        });
+      }
+    }
+
+    const byPeriod = uniqueMap(courses.map((c) => [c.period, c.externalId] as const));
+    const byTitle = uniqueMap(
+      courses
+        .filter((c) => normalizeName(c.title).length >= 4)
+        .map((c) => [normalizeName(c.title), c.externalId] as const)
+    );
+    const titleById = new Map(courses.map((c) => [c.externalId, c.title] as const));
+
+    const resolveCourseId = (period?: string, courseName?: string): string | undefined => {
+      if (period) {
+        const byP = byPeriod.get(period);
+        if (byP) return byP;
+      }
+      if (courseName) {
+        const normalized = normalizeName(courseName);
+        if (normalized.length >= 4) return byTitle.get(normalized);
+      }
+      return undefined;
+    };
+
+    return ops.map((item) => {
+      if (item.op !== 'upsert') return item;
+      const rec = recordOf(item);
+
+      if (item.entity === 'attendanceEvent') {
+        const period = asNonEmptyString(rec['periodName']) ?? asNonEmptyString(rec['period']);
+        const courseName = asNonEmptyString(rec['courseName']);
+        const courseId = resolveCourseId(period, courseName);
+        if (!courseId) return item;
+        const patch: Partial<Record<AllowedRecordField, string>> = { courseExternalId: courseId };
+        const title = titleById.get(courseId);
+        if (title && isEmpty(rec['courseName'])) patch.courseName = title;
+        return patchOp(item, patch);
+      }
+
+      if (item.entity === 'assignment' || item.entity === 'gradeSnapshot') {
+        const courseName = asNonEmptyString(rec['courseName']);
+        const courseId = resolveCourseId(undefined, courseName);
+        if (!courseId) return item;
+        return patchOp(item, { courseExternalId: courseId });
+      }
+
+      if (item.entity === 'message') {
+        const haystack = `${asNonEmptyString(rec['subject']) ?? ''} ${asNonEmptyString(rec['body']) ?? ''}`;
+        const assignmentId = matchAssignmentId(haystack, assignments);
+        if (!assignmentId) return item;
+        return patchOp(item, { assignmentExternalId: assignmentId });
+      }
+
+      if (item.entity === 'courseMaterial') {
+        const haystack = asNonEmptyString(rec['title']) ?? asNonEmptyString(rec['fileName']) ?? '';
+        const preferCourse =
+          asNonEmptyString(item.key.courseExternalId) ?? asNonEmptyString(rec['courseExternalId']);
+        const assignmentId = matchAssignmentId(haystack, assignments, preferCourse);
+        if (!assignmentId) return item;
+        return patchOp(item, { assignmentExternalId: assignmentId });
+      }
+
+      return item;
+    });
+  }
+}

--- a/packages/scraper-core/src/pipeline/index.ts
+++ b/packages/scraper-core/src/pipeline/index.ts
@@ -1,0 +1,8 @@
+export * from './types';
+export { runClientScrape, buildClientScrapeConfig } from './runClientScrape';
+export {
+  JoinGapEnricher,
+  applyEnrichersFailOpen,
+  sanitizeEnrichedOps,
+  DEFAULT_ENRICHER_TIMEOUT_MS,
+} from './enrichment';

--- a/packages/scraper-core/src/pipeline/runClientScrape.test.ts
+++ b/packages/scraper-core/src/pipeline/runClientScrape.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Pipeline tests for fail-open enrichment. Uses a stub IScraperResolver so
+ * recipes never run (ISP: host may inject a resolver).
+ */
+
+import type { ISlcDeltaOp } from '@scholaracle/contracts';
+import { FakePageDriver } from '../driver/FakePageDriver';
+import type { IScraperModule, IScraperResolver } from '../registry/module';
+import type { IAIEnricher, IClientScrapeHost, IIngestUploader } from './types';
+import { runClientScrape } from './runClientScrape';
+
+const NOW = '2026-01-15T10:00:00.000Z';
+
+function op(
+  entity: ISlcDeltaOp['entity'],
+  externalId: string,
+  record: Record<string, unknown>
+): ISlcDeltaOp {
+  return {
+    op: 'upsert',
+    entity,
+    key: {
+      provider: 'skyward',
+      adapterId: 'com.skyward.grade',
+      studentExternalId: 'stu-1',
+      institutionExternalId: 'inst-1',
+      externalId,
+    },
+    observedAt: NOW,
+    record,
+  };
+}
+
+const COURSE = op('course', 'skyward-course-A1', {
+  title: 'ALGEBRA 1',
+  period: '1',
+  teacherName: 'Smith',
+});
+const ATTENDANCE_GAP = op('attendanceEvent', 'att-1', {
+  date: '2026-01-10',
+  status: 'present',
+  periodName: '1',
+});
+
+function stubResolver(ops: ISlcDeltaOp[]): IScraperResolver {
+  const module: IScraperModule = {
+    metadata: {
+      id: 'skyward',
+      name: 'Skyward',
+      adapterId: 'com.skyward.grade',
+      version: '0.1.0',
+      hosts: ['*.skyward.com'],
+      entities: ['course', 'attendanceEvent'],
+      entry: 'builtin:skyward',
+      publisher: 'scholaracle',
+    },
+    scrape: async () => ({ student: 'Emma', courses: [], timestamp: NOW }),
+    transform: () => ops,
+  };
+  return {
+    async resolve() {
+      return { module, canRun: true, checkErrors: [] };
+    },
+  };
+}
+
+function makeHost(
+  ops: ISlcDeltaOp[],
+  extra: Partial<IClientScrapeHost> = {}
+): { host: IClientScrapeHost; uploaded: ISlcDeltaOp[][]; progress: string[] } {
+  const uploaded: ISlcDeltaOp[][] = [];
+  const progress: string[] = [];
+  const uploader: IIngestUploader = {
+    async upload(envelope) {
+      uploaded.push([...envelope.ops]);
+    },
+  };
+  const host: IClientScrapeHost = {
+    driver: new FakePageDriver(),
+    config: {
+      provider: 'skyward',
+      adapterId: 'com.skyward.grade',
+      adapterVersion: 'test@1.0.0',
+      baseUrl: 'https://school.skyward.com',
+      sourceId: 'src-1',
+      studentExternalId: 'stu-1',
+      institutionExternalId: 'inst-1',
+    },
+    clientType: 'mobile',
+    uploader,
+    resolver: stubResolver(ops),
+    onProgress: (p) => progress.push(`${p.phase}:${p.message}`),
+    ...extra,
+  };
+  return { host, uploaded, progress };
+}
+
+describe('runClientScrape enrichment', () => {
+  it('applies JoinGapEnricher by default so mobile needs no extra argument', async () => {
+    const { host, uploaded } = makeHost([COURSE, ATTENDANCE_GAP]);
+    const envelope = await runClientScrape(host);
+    expect(envelope.ops[1]?.record?.['courseExternalId']).toBe('skyward-course-A1');
+    expect(uploaded[0]?.[1]?.record?.['courseExternalId']).toBe('skyward-course-A1');
+    expect(envelope.run.meta?.['enrichmentSource']).toMatch(/join-gap/);
+    expect(Number(envelope.run.meta?.['enrichmentPatchCount'])).toBeGreaterThan(0);
+  });
+
+  it('still uploads original ops when the host enricher throws', async () => {
+    const boom: IAIEnricher = {
+      async enrich() {
+        throw new Error('llm 500');
+      },
+    };
+    const { host } = makeHost([COURSE, ATTENDANCE_GAP], { enricher: boom });
+    const envelope = await runClientScrape(host);
+    // JoinGap ran first; host failure must not roll that back or fail the sync
+    expect(envelope.ops[1]?.record?.['courseExternalId']).toBe('skyward-course-A1');
+    expect(envelope.run.meta?.['enrichmentFailed']).toBe('true');
+  });
+
+  it('does not throw SyncError when the host enricher hangs past timeout', async () => {
+    const hung: IAIEnricher = {
+      enrich: () => new Promise(() => undefined),
+    };
+    const { host } = makeHost([COURSE, ATTENDANCE_GAP], {
+      enricher: hung,
+      enricherTimeoutMs: 20,
+    });
+    const envelope = await runClientScrape(host);
+    expect(envelope.ops[1]?.record?.['courseExternalId']).toBe('skyward-course-A1');
+    expect(envelope.run.meta?.['enrichmentFailed']).toBe('true');
+  });
+
+  it('rejects host patches that invent externalIds', async () => {
+    const evil: IAIEnricher = {
+      async enrich(_raw, ops) {
+        return ops.map((o) =>
+          o.entity === 'course' ? { ...o, key: { ...o.key, externalId: 'invented' } } : o
+        );
+      },
+    };
+    const { host } = makeHost([COURSE, ATTENDANCE_GAP], { enricher: evil });
+    const envelope = await runClientScrape(host);
+    expect(envelope.ops[0]?.key.externalId).toBe('skyward-course-A1');
+  });
+});

--- a/packages/scraper-core/src/pipeline/runClientScrape.ts
+++ b/packages/scraper-core/src/pipeline/runClientScrape.ts
@@ -1,0 +1,283 @@
+/**
+ * runClientScrape — unified client scrape pipeline.
+ *
+ * All three clients (mobile, browser extension, CLI) call this function after
+ * the platform-specific authentication step. It encapsulates:
+ *   1. Module resolution (provider → IScraperModule)
+ *   2. Extraction (calls module.scrape via IScraperHost)
+ *   3. Transformation (calls module.transform)
+ *   4. Optional asset processing (CLI only)
+ *   5. Envelope assembly + validation
+ *   6. Upload via IIngestUploader
+ *   7. Optional run recording
+ */
+
+import { randomUUID } from './uuid';
+import { SLC_INGEST_SCHEMA_VERSION_V1, type ISlcIngestEnvelopeV1 } from '@scholaracle/contracts';
+import { validateEnvelope } from '../validator/validator';
+import { BuiltinScraperResolver } from '../registry/resolvers';
+import type { IScraperHost } from '../registry/module';
+import { SCRAPER_CORE_PACKAGE_VERSION } from '../version';
+import type {
+  IClientScrapeHost,
+  IClientScrapeConfig,
+  ISyncProgress,
+  SyncPhase,
+  IPhaseRecord,
+  SyncFailurePhase,
+} from './types';
+import { SyncError } from './types';
+import { applyEnrichersFailOpen, JoinGapEnricher } from './enrichment';
+
+const defaultResolver = new BuiltinScraperResolver();
+const defaultJoinGapEnricher = new JoinGapEnricher();
+
+function toSyncError(err: unknown, phase: SyncFailurePhase, fallback: string): SyncError {
+  if (err instanceof SyncError) return err;
+  const message = err instanceof Error ? err.message : fallback;
+  return new SyncError(message, phase, err);
+}
+
+function buildScraperHost(
+  host: IClientScrapeHost,
+  onPhaseProgress: (p: ISyncProgress) => void
+): IScraperHost {
+  return {
+    driver: host.driver,
+    config: {
+      baseUrl: host.config.baseUrl,
+      studentExternalId: host.config.studentExternalId,
+      studentNameHint: host.config.studentNameHint,
+    },
+    progress: (scraperProgress) => {
+      onPhaseProgress({
+        phase: 'extracting',
+        message: scraperProgress.message,
+      });
+    },
+  };
+}
+
+function buildEnvelopeMeta(
+  host: IClientScrapeHost,
+  enrichment?: { source: string; patchCount: number; failed: boolean }
+): Readonly<Record<string, string>> {
+  const meta: Record<string, string> = {
+    clientType: host.clientType,
+    coreVersion: host.config.coreVersion ?? SCRAPER_CORE_PACKAGE_VERSION,
+    adapterVersion: host.config.adapterVersion,
+  };
+  if (enrichment) {
+    meta['enrichmentSource'] = enrichment.source;
+    meta['enrichmentPatchCount'] = String(enrichment.patchCount);
+    meta['enrichmentFailed'] = enrichment.failed ? 'true' : 'false';
+  }
+  return meta;
+}
+
+export async function runClientScrape(host: IClientScrapeHost): Promise<ISlcIngestEnvelopeV1> {
+  const { config, uploader, recorder, assets, onProgress } = host;
+  const resolver = host.resolver ?? defaultResolver;
+  const runId = randomUUID();
+  const coreVersion = config.coreVersion ?? SCRAPER_CORE_PACKAGE_VERSION;
+  const startedAt = new Date().toISOString();
+
+  const phaseStart = { current: Date.now() };
+
+  const emit = async (
+    phase: SyncPhase,
+    message: string,
+    extra?: { opCount?: number }
+  ): Promise<void> => {
+    const now = Date.now();
+    const durationMs = now - phaseStart.current;
+    phaseStart.current = now;
+    const record: IPhaseRecord = {
+      phase,
+      message,
+      timestamp: new Date(now).toISOString(),
+      durationMs,
+    };
+    if (recorder) {
+      await recorder.addPhase(runId, record).catch(() => undefined);
+    }
+    onProgress?.({ phase, message, ...extra });
+  };
+
+  // 0. Register run in local recorder (optional)
+  if (recorder) {
+    await recorder
+      .startRun({
+        runId,
+        provider: config.provider,
+        studentExternalId: config.studentExternalId,
+        adapterVersion: config.adapterVersion,
+        coreVersion,
+      })
+      .catch(() => undefined);
+  }
+
+  // 1. Resolve module
+  const { module } = await resolver.resolve(config.provider).catch((err: unknown) => {
+    throw toSyncError(err, 'local', `Unknown provider: ${config.provider}`);
+  });
+
+  // 2. Extract (portal step)
+  await emit('extracting', 'Extracting data from portal...');
+
+  let raw: Record<string, unknown>;
+  try {
+    const scraperHost = buildScraperHost(host, (p) => onProgress?.(p));
+    raw = await module.scrape(scraperHost);
+  } catch (err: unknown) {
+    const syncErr = toSyncError(err, 'portal', 'Extract failed');
+    if (recorder) {
+      await recorder
+        .completeRun(runId, { status: 'failed', errorMessage: syncErr.message })
+        .catch(() => undefined);
+    }
+    await uploader.reportFailure?.(runId, config.sourceId, syncErr.message).catch(() => undefined);
+    throw syncErr;
+  }
+
+  // 3. Transform (local step)
+  await emit('transforming', 'Converting data...');
+
+  let ops: ReturnType<typeof module.transform>;
+  try {
+    const ctx = {
+      provider: config.provider,
+      adapterId: config.adapterId,
+      studentExternalId: config.studentExternalId,
+      institutionExternalId: config.institutionExternalId,
+    };
+    ops = module.transform(raw, ctx);
+  } catch (err: unknown) {
+    const syncErr = toSyncError(err, 'local', 'Transform failed');
+    if (recorder) {
+      await recorder
+        .completeRun(runId, { status: 'failed', errorMessage: syncErr.message })
+        .catch(() => undefined);
+    }
+    throw syncErr;
+  }
+
+  await emit('transforming', `Produced ${ops.length} operations`, { opCount: ops.length });
+
+  // 4. Optional asset processing (CLI only)
+  if (assets) {
+    try {
+      ops = await assets.processOps(ops);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await emit('transforming', `Asset processing failed — continuing: ${msg}`);
+    }
+  }
+
+  // 4b. Join-gap enricher (always) then optional host enricher — both fail-open
+  await emit('transforming', 'Joining subjects, grades, and resources...');
+  const enrichers = host.enricher
+    ? [defaultJoinGapEnricher, host.enricher]
+    : [defaultJoinGapEnricher];
+  const enrichment = await applyEnrichersFailOpen({
+    enrichers,
+    rawExtract: raw,
+    ops,
+    timeoutMs: host.enricherTimeoutMs,
+    onWarning: (message) => {
+      void emit('transforming', `Enrichment warning — continuing: ${message}`);
+    },
+  });
+  ops = enrichment.ops;
+  const enrichmentSource = host.enricher ? 'join-gap+host' : 'join-gap';
+
+  // 5. Assemble + validate envelope
+  await emit('validating', 'Validating envelope...');
+
+  const endedAt = new Date().toISOString();
+  const envelope: ISlcIngestEnvelopeV1 = {
+    schemaVersion: SLC_INGEST_SCHEMA_VERSION_V1,
+    run: {
+      runId,
+      startedAt,
+      endedAt,
+      provider: config.provider,
+      adapterId: config.adapterId,
+      adapterVersion: config.adapterVersion,
+      mode: 'delta',
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      meta: buildEnvelopeMeta(host, {
+        source: enrichmentSource,
+        patchCount: enrichment.patchCount,
+        failed: enrichment.failed,
+      }),
+    },
+    source: {
+      sourceId: config.sourceId,
+      displayName: `${config.provider} (${host.clientType})`,
+      portalBaseUrl: config.baseUrl,
+    },
+    ops,
+  };
+
+  const report = validateEnvelope(envelope);
+  if (!report.passed) {
+    const msg = `Envelope validation failed: ${report.errorCount} errors`;
+    if (recorder) {
+      await recorder
+        .completeRun(runId, { status: 'failed', opCount: ops.length, errorMessage: msg })
+        .catch(() => undefined);
+    }
+    await uploader.reportFailure?.(runId, config.sourceId, msg).catch(() => undefined);
+    throw new SyncError(msg, 'local');
+  }
+
+  // 6. Upload
+  await emit('uploading', 'Uploading to Scholaracle...');
+
+  try {
+    await uploader.upload(envelope);
+  } catch (err: unknown) {
+    const syncErr = toSyncError(err, 'upload', 'Upload failed');
+    if (recorder) {
+      await recorder
+        .completeRun(runId, {
+          status: 'failed',
+          opCount: ops.length,
+          errorMessage: syncErr.message,
+        })
+        .catch(() => undefined);
+    }
+    throw syncErr;
+  }
+
+  // 7. Record success
+  if (recorder) {
+    await recorder
+      .completeRun(runId, { status: 'success', opCount: ops.length })
+      .catch(() => undefined);
+  }
+  await emit('complete', `Sync complete — ${ops.length} ops`, { opCount: ops.length });
+
+  return envelope;
+}
+
+/** Build IClientScrapeConfig from any scraper-config-like object. */
+export function buildClientScrapeConfig(
+  params: Pick<
+    IClientScrapeConfig,
+    | 'provider'
+    | 'adapterId'
+    | 'adapterVersion'
+    | 'baseUrl'
+    | 'sourceId'
+    | 'studentExternalId'
+    | 'institutionExternalId'
+  > &
+    Partial<Pick<IClientScrapeConfig, 'studentNameHint' | 'coreVersion'>>
+): IClientScrapeConfig {
+  return {
+    ...params,
+    coreVersion: params.coreVersion ?? SCRAPER_CORE_PACKAGE_VERSION,
+  };
+}

--- a/packages/scraper-core/src/pipeline/types.ts
+++ b/packages/scraper-core/src/pipeline/types.ts
@@ -1,0 +1,195 @@
+/**
+ * Shared types for the unified client scrape pipeline.
+ *
+ * Consumed by: scraper-core (runClientScrape), mobile (SyncOrchestrator),
+ * browser-extension (content-script), and CLI (BaseScraper adapters).
+ */
+
+import type { ISlcIngestEnvelopeV1, ISlcDeltaOp } from '@scholaracle/contracts';
+import type { IPageDriver } from '../driver/IPageDriver';
+import type { IScraperResolver } from '../registry/module';
+
+// ---------------------------------------------------------------------------
+// Progress
+// ---------------------------------------------------------------------------
+
+export type SyncPhase =
+  'idle' | 'extracting' | 'transforming' | 'validating' | 'uploading' | 'complete' | 'error';
+
+export interface ISyncProgress {
+  readonly phase: SyncPhase;
+  readonly message: string;
+  readonly opCount?: number;
+}
+
+export type SyncProgressCallback = (progress: ISyncProgress) => void;
+
+// ---------------------------------------------------------------------------
+// Failure
+// ---------------------------------------------------------------------------
+
+export type SyncFailurePhase = 'portal' | 'upload' | 'local';
+
+export class SyncError extends Error {
+  readonly phase: SyncFailurePhase;
+
+  constructor(message: string, phase: SyncFailurePhase, cause?: unknown) {
+    super(message);
+    this.name = 'SyncError';
+    this.phase = phase;
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Client type
+// ---------------------------------------------------------------------------
+
+export type ClientType = 'mobile' | 'browser-extension' | 'cli';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface IClientScrapeConfig {
+  readonly provider: string;
+  readonly adapterId: string;
+  readonly adapterVersion: string;
+  readonly baseUrl: string;
+  readonly sourceId: string;
+  readonly studentExternalId: string;
+  readonly institutionExternalId: string;
+  readonly studentNameHint?: string;
+  /** scraper-core semver string. */
+  readonly coreVersion?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Ingest uploader
+// ---------------------------------------------------------------------------
+
+/**
+ * Client-side ingest uploader contract.
+ *
+ * Implementations MUST use the three-step canonical protocol:
+ *   POST /api/ingest/v1/runs
+ *   POST /api/ingest/v1/runs/:runId/envelope
+ *   POST /api/ingest/v1/runs/:runId/complete
+ *
+ * Each client implementation handles the HTTP details; runClientScrape
+ * calls upload() without caring about the underlying steps.
+ */
+export interface IIngestUploader {
+  /**
+   * Upload the complete envelope. Implementations handle run registration,
+   * envelope delivery, and run completion internally.
+   */
+  upload(envelope: ISlcIngestEnvelopeV1): Promise<void>;
+
+  /**
+   * Report a failed run to the server (extraction or validation failed
+   * before upload). Optional — implementations may no-op this.
+   */
+  reportFailure?(runId: string, sourceId: string, error: string): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Optional: asset processing (CLI only)
+// ---------------------------------------------------------------------------
+
+export interface IAssetHost {
+  /**
+   * Process ops that contain local file paths or temporary URLs:
+   * download assets, upload to permanent storage, rewrite URLs.
+   * Returns the mutated ops array.
+   */
+  processOps(ops: ISlcDeltaOp[]): Promise<ISlcDeltaOp[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Optional: join / AI enrichment (fail-open)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fill empty join fields after transform. Implementations MUST NOT throw
+ * in a way that fails the sync — `runClientScrape` swallows errors, timeouts,
+ * and illegal patches (invented ids, added/removed ops, overwrites).
+ *
+ * Allowlisted record fields: courseExternalId, assignmentExternalId, courseName.
+ * Native key.externalId is immutable.
+ */
+export interface IAIEnricher {
+  enrich(rawExtract: Record<string, unknown>, ops: ISlcDeltaOp[]): Promise<ISlcDeltaOp[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Optional: local run recorder (mobile / CLI)
+// ---------------------------------------------------------------------------
+
+export interface IStartRunParams {
+  readonly runId: string;
+  readonly provider: string;
+  readonly studentExternalId: string;
+  readonly adapterVersion: string;
+  readonly coreVersion: string;
+}
+
+export interface IPhaseRecord {
+  readonly phase: SyncPhase;
+  readonly message: string;
+  readonly timestamp: string;
+  readonly durationMs: number;
+}
+
+export interface IRunResult {
+  readonly status: 'success' | 'failed';
+  readonly opCount?: number;
+  readonly errorMessage?: string;
+}
+
+export interface IRunRecorder {
+  startRun(params: IStartRunParams): Promise<void>;
+  addPhase(runId: string, phase: IPhaseRecord): Promise<void>;
+  completeRun(runId: string, result: IRunResult): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Host interface
+// ---------------------------------------------------------------------------
+
+export interface IClientScrapeHost {
+  /** Live, authenticated page driver handed to the module's scrape() call. */
+  readonly driver: IPageDriver;
+  /** Resolved config for this run. */
+  readonly config: IClientScrapeConfig;
+  /** Client identifier used in envelope meta. */
+  readonly clientType: ClientType;
+  /** Three-step ingest uploader. */
+  readonly uploader: IIngestUploader;
+  /**
+   * Optional asset host (CLI only). When present, pipeline processes ops
+   * before upload so that local file paths are rewritten to permanent URLs.
+   */
+  readonly assets?: IAssetHost;
+  /**
+   * Optional run recorder for local sync history persistence
+   * (mobile / CLI). Extension may omit.
+   */
+  readonly recorder?: IRunRecorder;
+  /**
+   * Optional extra enricher (LLM, on-device, API). Always runs *after*
+   * the built-in JoinGapEnricher. Fail-open: throw/timeout/illegal patch
+   * cannot fail the sync.
+   */
+  readonly enricher?: IAIEnricher;
+  /**
+   * Timeout for each enricher call. Defaults to DEFAULT_ENRICHER_TIMEOUT_MS.
+   */
+  readonly enricherTimeoutMs?: number;
+  /**
+   * Optional resolver override (tests / sideload). Defaults to builtins.
+   */
+  readonly resolver?: IScraperResolver;
+  /** Emit progress events back to the caller UI. */
+  readonly onProgress?: SyncProgressCallback;
+}

--- a/packages/scraper-core/src/pipeline/uuid.ts
+++ b/packages/scraper-core/src/pipeline/uuid.ts
@@ -1,0 +1,21 @@
+/**
+ * Cross-platform UUID v4 generator for scraper-core.
+ *
+ * Priority:
+ *   1. globalThis.crypto.randomUUID (browser, Node 19+, React Native via Expo)
+ *   2. Pure-JS math-random fallback (non-cryptographic, for older environments)
+ */
+
+declare const crypto: { randomUUID?: () => string } | undefined;
+
+export function randomUUID(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // RFC 4122 v4 UUID
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}

--- a/packages/scraper-core/src/recipes/skyward-recipe.ts
+++ b/packages/scraper-core/src/recipes/skyward-recipe.ts
@@ -165,11 +165,10 @@ export async function runSkywardRecipe(
       // Extract assignments from the gradeInfoDialog if visible after grade cell click
       for (const period of GRADE_PERIOD_PRIORITY) {
         void period; // iterate periods until assignments are found
-        const assignments = await driver.evaluate(
-          extractSkywardCourseAssignments,
-          course.name,
-          course.period
-        );
+        const assignments = await driver.evaluate(extractSkywardCourseAssignments, {
+          courseName: course.name,
+          coursePeriod: course.period,
+        });
         if (assignments.length > 0) {
           allAssignments.push(...assignments);
           break;

--- a/packages/scraper-core/src/registry/builtin-modules.ts
+++ b/packages/scraper-core/src/registry/builtin-modules.ts
@@ -134,9 +134,11 @@ export const BUILTIN_ALIAS_TO_ADAPTER: Readonly<Record<string, string>> = {
   skyward: 'com.skyward.qmlativ',
   'com.skyward': 'com.skyward.qmlativ',
   'com.skyward.qmlativ': 'com.skyward.qmlativ',
+  'com.skyward.iscorp': 'com.skyward.qmlativ',
   aeries: 'com.aeries.sis',
   'com.aeries': 'com.aeries.sis',
   'com.aeries.sis': 'com.aeries.sis',
+  'com.aeries.portal': 'com.aeries.sis',
 };
 
 export const BUILTIN_MODULES_BY_ADAPTER: Readonly<Record<string, IScraperModule>> = {

--- a/packages/scraper-core/src/registry/resolvers.test.ts
+++ b/packages/scraper-core/src/registry/resolvers.test.ts
@@ -57,8 +57,10 @@ describe('BuiltinScraperResolver', () => {
     ['com.instructure.canvas', 'com.instructure.canvas'],
     ['skyward', 'com.skyward.qmlativ'],
     ['com.skyward.qmlativ', 'com.skyward.qmlativ'],
+    ['com.skyward.iscorp', 'com.skyward.qmlativ'],
     ['aeries', 'com.aeries.sis'],
     ['com.aeries.sis', 'com.aeries.sis'],
+    ['com.aeries.portal', 'com.aeries.sis'],
   ] as const)('resolves %s → adapterId %s', async (key, adapterId) => {
     const result = await resolver.resolve(key);
     expect(result.module.metadata.adapterId).toBe(adapterId);

--- a/packages/scraper-core/src/transformers/aeries/aeries-transformer.test.ts
+++ b/packages/scraper-core/src/transformers/aeries/aeries-transformer.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Aeries transformer tests — TDD for stable course/assignment IDs, teacher ops,
+ * academicTerm, and attendance courseExternalId.
+ */
+
+import { transformAeriesExtract, type IAeriesFullExtract } from '../../index';
+import type { ITransformContext } from '../../types';
+
+const ctx: ITransformContext = {
+  provider: 'aeries',
+  adapterId: 'com.aeries.portal',
+  studentExternalId: 'stu-emma',
+  institutionExternalId: 'inst-test',
+};
+
+function makeExtract(overrides: Partial<IAeriesFullExtract> = {}): IAeriesFullExtract {
+  return {
+    students: [],
+    timestamp: '2026-01-15T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeStudent(overrides: Partial<IAeriesFullExtract['students'][number]> = {}) {
+  return {
+    name: 'Emma Lewis',
+    studentId: 'S12345',
+    grade: '10',
+    school: 'Central HS',
+    courses: [],
+    attendance: [],
+    ...overrides,
+  };
+}
+
+function makeCourse(
+  overrides: Partial<IAeriesFullExtract['students'][number]['courses'][number]> = {}
+) {
+  return {
+    period: '3',
+    name: 'English 2',
+    term: 'Q3',
+    teacher: 'Jones, Mary',
+    teacherEmail: 'mjones@school.edu',
+    room: '205',
+    currentGrade: null,
+    currentPercent: null,
+    missingCount: 0,
+    assignments: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// native-ids: stable course externalId
+// ---------------------------------------------------------------------------
+
+describe('native IDs — Aeries', () => {
+  it('course externalId uses studentId+period+slug, NOT array index', () => {
+    const extract = makeExtract({ students: [makeStudent({ courses: [makeCourse()] })] });
+    const ops = transformAeriesExtract(extract, ctx);
+    const courseOp = ops.find((o) => o.entity === 'course');
+    expect(courseOp?.key.externalId).toBe('aeries-course-S12345-3-english-2');
+    // must NOT contain an array index segment (no bare number between two dashes)
+    expect(courseOp?.key.externalId).not.toMatch(/aeries-course-S12345-\d+-\d/);
+  });
+
+  it('course externalId is stable across re-runs (same period+name → same id)', () => {
+    const makeOps = () =>
+      transformAeriesExtract(
+        makeExtract({ students: [makeStudent({ courses: [makeCourse()] })] }),
+        ctx
+      );
+    expect(makeOps()[0]?.key.externalId).toBe(makeOps()[0]?.key.externalId);
+  });
+
+  it('assignment externalId uses studentId+period+number when number present', () => {
+    const extract = makeExtract({
+      students: [
+        makeStudent({
+          courses: [
+            makeCourse({
+              assignments: [
+                {
+                  number: '42',
+                  title: 'HW 5',
+                  category: 'HW',
+                  scoreEarned: null,
+                  scorePossible: 10,
+                  percentCorrect: null,
+                  dateAssigned: '01/05/2026',
+                  dateDue: '01/10/2026',
+                  dateCompleted: '',
+                  gradingComplete: false,
+                  isMissing: false,
+                  comment: '',
+                },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+    const ops = transformAeriesExtract(extract, ctx);
+    const assignOp = ops.find((o) => o.entity === 'assignment');
+    expect(assignOp?.key.externalId).toBe('aeries-assign-S12345-3-42');
+  });
+
+  it('assignment externalId falls back to date+title-slug when number absent', () => {
+    const extract = makeExtract({
+      students: [
+        makeStudent({
+          courses: [
+            makeCourse({
+              assignments: [
+                {
+                  number: '',
+                  title: 'Untitled',
+                  category: '',
+                  scoreEarned: null,
+                  scorePossible: null,
+                  percentCorrect: null,
+                  dateAssigned: '01/05/2026',
+                  dateDue: '01/10/2026',
+                  dateCompleted: '',
+                  gradingComplete: false,
+                  isMissing: false,
+                  comment: '',
+                },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+    const ops = transformAeriesExtract(extract, ctx);
+    const assignOp = ops.find((o) => o.entity === 'assignment');
+    // fallback must still include studentId and period
+    expect(assignOp?.key.externalId).toMatch(/^aeries-assign-S12345-3-/);
+  });
+
+  it('gradeSnapshot courseExternalId reflects new stable course id', () => {
+    const extract = makeExtract({
+      students: [makeStudent({ courses: [makeCourse({ currentPercent: 92 })] })],
+    });
+    const ops = transformAeriesExtract(extract, ctx);
+    const gradeOp = ops.find((o) => o.entity === 'gradeSnapshot');
+    expect(gradeOp?.key.courseExternalId).toBe('aeries-course-S12345-3-english-2');
+    expect(gradeOp?.record?.['courseExternalId']).toBe('aeries-course-S12345-3-english-2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// four-pictures: academicTerm from course.term
+// ---------------------------------------------------------------------------
+
+describe('academicTerm — Aeries', () => {
+  it('emits an academicTerm op for each distinct term value', () => {
+    const extract = makeExtract({
+      students: [
+        makeStudent({
+          courses: [
+            makeCourse({ period: '1', term: 'Quarter 3' }),
+            makeCourse({ period: '2', name: 'Math', term: 'Quarter 3' }),
+            makeCourse({ period: '3', name: 'History', term: 'Semester 2' }),
+          ],
+        }),
+      ],
+    });
+    const ops = transformAeriesExtract(extract, ctx);
+    const termOps = ops.filter((o) => o.entity === 'academicTerm');
+    const externalIds = termOps.map((o) => o.key.externalId);
+    expect(externalIds).toContain('aeries-term-quarter-3');
+    expect(externalIds).toContain('aeries-term-semester-2');
+    // Deduplicated — no duplicates
+    expect(new Set(externalIds).size).toBe(externalIds.length);
+  });
+
+  it('does not emit academicTerm when term is blank', () => {
+    const extract = makeExtract({
+      students: [makeStudent({ courses: [makeCourse({ term: '' })] })],
+    });
+    const ops = transformAeriesExtract(extract, ctx);
+    const termOps = ops.filter((o) => o.entity === 'academicTerm');
+    expect(termOps).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// four-pictures: teacher ops from courses
+// ---------------------------------------------------------------------------
+
+describe('teacher ops — Aeries', () => {
+  it('emits a teacher op for each course that has a teacher', () => {
+    const extract = makeExtract({
+      students: [
+        makeStudent({
+          courses: [
+            makeCourse({ teacher: 'Jones, Mary', teacherEmail: 'mjones@school.edu' }),
+            makeCourse({
+              period: '4',
+              name: 'Math',
+              teacher: 'Kim, Alex',
+              teacherEmail: 'akim@school.edu',
+            }),
+          ],
+        }),
+      ],
+    });
+    const ops = transformAeriesExtract(extract, ctx);
+    const teacherOps = ops.filter((o) => o.entity === 'teacher');
+    expect(teacherOps.length).toBeGreaterThanOrEqual(2);
+    expect(teacherOps.some((o) => o.record?.['name'] === 'Jones, Mary')).toBe(true);
+    expect(teacherOps.some((o) => o.record?.['name'] === 'Kim, Alex')).toBe(true);
+  });
+
+  it('deduplicates the same teacher by name+email across courses', () => {
+    const extract = makeExtract({
+      students: [
+        makeStudent({
+          courses: [
+            makeCourse({ period: '1', teacher: 'Smith, Bob', teacherEmail: 'bsmith@school.edu' }),
+            makeCourse({
+              period: '2',
+              name: 'Honors Math',
+              teacher: 'Smith, Bob',
+              teacherEmail: 'bsmith@school.edu',
+            }),
+          ],
+        }),
+      ],
+    });
+    const ops = transformAeriesExtract(extract, ctx);
+    const teacherOps = ops.filter((o) => o.entity === 'teacher');
+    expect(teacherOps.filter((o) => o.record?.['name'] === 'Smith, Bob')).toHaveLength(1);
+  });
+
+  it('teacher record includes email and courseExternalIds', () => {
+    const extract = makeExtract({
+      students: [makeStudent({ courses: [makeCourse()] })],
+    });
+    const ops = transformAeriesExtract(extract, ctx);
+    const teacherOp = ops.find((o) => o.entity === 'teacher');
+    expect(teacherOp?.record?.['email']).toBe('mjones@school.edu');
+    expect(teacherOp?.record?.['courseExternalIds']).toContain('aeries-course-S12345-3-english-2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// four-pictures: attendance courseExternalId FK
+// ---------------------------------------------------------------------------
+
+describe('attendance courseExternalId — Aeries', () => {
+  it('emits courseExternalId on attendanceEvent when period matches a course', () => {
+    const extract = makeExtract({
+      students: [
+        makeStudent({
+          courses: [makeCourse()], // period '3'
+          attendance: [
+            { date: '01/10/2026', period: '3', status: 'Present', reason: '', course: 'English 2' },
+          ],
+        }),
+      ],
+    });
+    const ops = transformAeriesExtract(extract, ctx);
+    const attOp = ops.find((o) => o.entity === 'attendanceEvent');
+    expect(attOp?.record?.['courseExternalId']).toBe('aeries-course-S12345-3-english-2');
+  });
+
+  it('attendance externalId uses date+period, not array index', () => {
+    const extract = makeExtract({
+      students: [
+        makeStudent({
+          attendance: [
+            { date: '01/10/2026', period: '3', status: 'Present', reason: '', course: '' },
+          ],
+        }),
+      ],
+    });
+    const ops = transformAeriesExtract(extract, ctx);
+    const attOp = ops.find((o) => o.entity === 'attendanceEvent');
+    expect(attOp?.key.externalId).toBe('aeries-attendance-S12345-2026-01-10-3');
+    // positive assertion above is sufficient — period suffix is expected
+  });
+});

--- a/packages/scraper-core/src/transformers/aeries/aeries-transformer.ts
+++ b/packages/scraper-core/src/transformers/aeries/aeries-transformer.ts
@@ -36,6 +36,15 @@ function parseDate(dateStr: string): string | undefined {
   return `${year}-${month!.padStart(2, '0')}-${day!.padStart(2, '0')}`;
 }
 
+function slugify(s: string): string {
+  return (
+    s
+      .replace(/\s+/g, '-')
+      .replace(/[^a-zA-Z0-9-]/g, '')
+      .toLowerCase() || 'unknown'
+  );
+}
+
 export function transformAeriesExtract(
   extract: IAeriesFullExtract,
   ctx: ITransformContext
@@ -49,6 +58,7 @@ export function transformAeriesExtract(
   if (students.length === 0) return ops;
 
   const student = students[0]!;
+  const studentId = student.studentId || ctx.studentExternalId;
   const baseKey = {
     provider: ctx.provider,
     adapterId: ctx.adapterId,
@@ -63,7 +73,7 @@ export function transformAeriesExtract(
       entity: 'studentProfile',
       key: {
         ...baseKey,
-        externalId: `aeries-profile-${student.studentId || ctx.studentExternalId}`,
+        externalId: `aeries-profile-${studentId}`,
       },
       observedAt: now,
       record: {
@@ -75,10 +85,41 @@ export function transformAeriesExtract(
     });
   }
 
+  // Academic terms — one per distinct, non-empty course.term value
+  const seenTerms = new Set<string>();
+  for (const course of student.courses) {
+    if (!course.term) continue;
+    const termExtId = `aeries-term-${slugify(course.term)}`;
+    if (!seenTerms.has(termExtId)) {
+      seenTerms.add(termExtId);
+      ops.push({
+        op: 'upsert',
+        entity: 'academicTerm',
+        key: { ...baseKey, externalId: termExtId },
+        observedAt: now,
+        record: {
+          title: course.term,
+          type: 'grading_period',
+        },
+      });
+    }
+  }
+
+  // Teachers — deduplicated by name+email
+  const seenTeachers = new Map<string, { name: string; email?: string; courseExtIds: string[] }>();
+
+  // Build course externalId lookup first for teacher/attendance joins
+  const courseExtIds: string[] = [];
+  for (const course of student.courses) {
+    // Stable ID: studentId + period + name-slug (no array index)
+    courseExtIds.push(`aeries-course-${studentId}-${course.period}-${slugify(course.name)}`);
+  }
+
   // Courses + grade snapshots + assignments
   for (let ci = 0; ci < student.courses.length; ci++) {
     const course = student.courses[ci]!;
-    const courseExtId = `aeries-course-${student.studentId || ctx.studentExternalId}-${ci}-${course.name.replace(/\s+/g, '-')}`;
+    const courseExtId = courseExtIds[ci]!;
+    const termExtId = course.term ? `aeries-term-${slugify(course.term)}` : undefined;
 
     ops.push({
       op: 'upsert',
@@ -91,8 +132,24 @@ export function transformAeriesExtract(
         teacherEmail: course.teacherEmail || undefined,
         period: course.period || undefined,
         room: course.room || undefined,
+        termExternalId: termExtId,
       },
     });
+
+    // Collect teacher for dedup pass below
+    if (course.teacher) {
+      const key = `${course.teacher}||${course.teacherEmail || ''}`;
+      const existing = seenTeachers.get(key);
+      if (existing) {
+        existing.courseExtIds.push(courseExtId);
+      } else {
+        seenTeachers.set(key, {
+          name: course.teacher,
+          email: course.teacherEmail || undefined,
+          courseExtIds: [courseExtId],
+        });
+      }
+    }
 
     // Grade snapshot per course (currentPercent -> percentGrade)
     if (course.currentPercent !== null || course.currentGrade !== null) {
@@ -114,10 +171,13 @@ export function transformAeriesExtract(
       });
     }
 
-    // Assignments
+    // Assignments — stable ID: studentId + period + assignment.number (or date+slug fallback)
     for (let ai = 0; ai < course.assignments.length; ai++) {
       const a = course.assignments[ai]!;
-      const aExtId = `aeries-${courseExtId}-assignment-${ai}`;
+      const assignSlug = a.number
+        ? a.number
+        : `${parseDate(a.dateDue) ?? 'nodate'}-${slugify(a.title).slice(0, 20)}`;
+      const aExtId = `aeries-assign-${studentId}-${course.period}-${assignSlug}`;
 
       let status:
         | 'missing'
@@ -148,18 +208,41 @@ export function transformAeriesExtract(
           category: a.category || undefined,
           isMissing: a.isMissing,
           courseExternalId: courseExtId,
+          termExternalId: termExtId,
         },
       });
     }
   }
 
-  // Attendance events
-  for (let ai = 0; ai < student.attendance.length; ai++) {
-    const att = student.attendance[ai]!;
-    const attExtId = `aeries-attendance-${student.studentId || ctx.studentExternalId}-${ai}-${att.date}`;
+  // Teacher ops (after course pass for courseExtIds)
+  for (const [, { name, email, courseExtIds: teacherCourseIds }] of seenTeachers) {
+    ops.push({
+      op: 'upsert',
+      entity: 'teacher',
+      key: { ...baseKey, externalId: `aeries-teacher-${studentId}-${slugify(name)}` },
+      observedAt: now,
+      record: {
+        name,
+        email,
+        courseExternalIds: teacherCourseIds,
+      },
+    });
+  }
 
+  // Build period→courseExtId lookup for attendance FK
+  const periodToCourseExtId = new Map<string, string>();
+  for (let ci = 0; ci < student.courses.length; ci++) {
+    const course = student.courses[ci]!;
+    if (course.period) periodToCourseExtId.set(course.period, courseExtIds[ci]!);
+  }
+
+  // Attendance events — stable ID: studentId + date + period
+  for (const att of student.attendance) {
     const dateStr = parseDate(att.date);
     if (!dateStr) continue;
+
+    const attExtId = `aeries-attendance-${studentId}-${dateStr}-${att.period || 'all'}`;
+    const courseExtId = att.period ? periodToCourseExtId.get(att.period) : undefined;
 
     ops.push({
       op: 'upsert',
@@ -171,6 +254,7 @@ export function transformAeriesExtract(
         status: normalizeAttendanceStatus(att.status),
         periodName: att.period || undefined,
         courseName: att.course || undefined,
+        courseExternalId: courseExtId || undefined,
         notes: att.reason || undefined,
         excuseReason: att.reason || undefined,
       },

--- a/packages/scraper-core/src/transformers/canvas/canvas-transformer.test.ts
+++ b/packages/scraper-core/src/transformers/canvas/canvas-transformer.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Canvas transformer tests — TDD for native IDs, announcement body, and
+ * material-to-assignment matching.
+ *
+ * RED → implement → GREEN
+ */
+
+import {
+  transformCanvasExtract,
+  matchMaterialsToAssignments,
+  type ICanvasBrowserExtract,
+  type ICanvasBrowserCourse,
+} from '../../index';
+import type { ITransformContext } from '../../types';
+
+const ctx: ITransformContext = {
+  provider: 'canvas',
+  adapterId: 'com.instructure.canvas',
+  studentExternalId: 'stu-emma',
+  institutionExternalId: 'inst-test',
+};
+
+function makeCourse(overrides: Partial<ICanvasBrowserCourse> = {}): ICanvasBrowserCourse {
+  return {
+    id: '101',
+    name: 'AP Math',
+    courseCode: 'MATH-AP',
+    teachers: [],
+    url: 'https://school.instructure.com/courses/101',
+    grade: undefined,
+    assignments: [],
+    modules: [],
+    files: [],
+    ...overrides,
+  };
+}
+
+function makeExtract(overrides: Partial<ICanvasBrowserExtract> = {}): ICanvasBrowserExtract {
+  return {
+    user: 'Emma Lewis',
+    courses: [],
+    toDoItems: [],
+    upcomingEvents: [],
+    announcements: [],
+    timestamp: '2026-01-15T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// NATIVE IDs
+// ---------------------------------------------------------------------------
+
+describe('native IDs — Canvas', () => {
+  it('assignment externalId uses native Canvas assignment ID, not array index', () => {
+    const extract = makeExtract({
+      courses: [
+        makeCourse({
+          assignments: [
+            { id: '987', name: 'Homework 1', dueDate: '2026-01-20T23:59:00Z', points: '10 pts' },
+            { id: '988', name: 'Homework 2', dueDate: '2026-01-27T23:59:00Z', points: '10 pts' },
+          ],
+        }),
+      ],
+    });
+    const ops = transformCanvasExtract(extract, ctx);
+    const assignOps = ops.filter((o) => o.entity === 'assignment');
+    expect(assignOps).toHaveLength(2);
+    expect(assignOps[0]?.key.externalId).toBe('canvas-assignment-987');
+    expect(assignOps[1]?.key.externalId).toBe('canvas-assignment-988');
+    // must NOT look like an index-based ID
+    expect(assignOps[0]?.key.externalId).not.toMatch(/-assignment-\d$/);
+  });
+
+  it('assignment externalId falls back to course+index when id absent', () => {
+    const extract = makeExtract({
+      courses: [
+        makeCourse({
+          assignments: [{ name: 'Untitled', dueDate: undefined, points: undefined }],
+        }),
+      ],
+    });
+    const ops = transformCanvasExtract(extract, ctx);
+    const assignOp = ops.find((o) => o.entity === 'assignment');
+    // fallback must still be stable and include courseId
+    expect(assignOp?.key.externalId).toMatch(/^canvas-assignment-101-/);
+  });
+
+  it('courseMaterial externalId uses native Canvas file ID, not file name', () => {
+    const extract = makeExtract({
+      courses: [
+        makeCourse({ files: [{ id: '555', name: 'notes.pdf', url: '/files/555/download' }] }),
+      ],
+    });
+    const ops = transformCanvasExtract(extract, ctx);
+    const matOp = ops.find((o) => o.entity === 'courseMaterial');
+    expect(matOp?.key.externalId).toBe('canvas-file-555');
+  });
+
+  it('courseMaterial externalId falls back to course+slug when file id absent', () => {
+    const extract = makeExtract({
+      courses: [makeCourse({ files: [{ name: 'notes.pdf', url: '/files/download' }] })],
+    });
+    const ops = transformCanvasExtract(extract, ctx);
+    const matOp = ops.find((o) => o.entity === 'courseMaterial');
+    expect(matOp?.key.externalId).toMatch(/^canvas-file-101-/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchMaterialsToAssignments — returns native IDs, not array indices
+// ---------------------------------------------------------------------------
+
+describe('matchMaterialsToAssignments — native IDs', () => {
+  it('maps file ID to native assignment ID via module co-occurrence', () => {
+    const course = makeCourse({
+      assignments: [
+        { id: '987', name: 'HW 1' },
+        { id: '988', name: 'HW 2' },
+      ],
+      files: [{ id: '555', name: 'worksheet.pdf', url: '' }],
+      modules: [
+        {
+          id: 'mod-1',
+          name: 'Module 1',
+          position: 1,
+          items: [
+            { title: 'HW 1', type: 'Assignment', contentId: '987', position: 1 },
+            { title: 'worksheet.pdf', type: 'File', contentId: '555', position: 2 },
+          ],
+        },
+      ],
+    });
+    const result = matchMaterialsToAssignments(course);
+    // Key is fileId, value is native assignment externalId
+    expect(result.get('555')).toBe('canvas-assignment-987');
+  });
+
+  it('maps file ID to native assignment ID via description link', () => {
+    const course = makeCourse({
+      assignments: [{ id: '987', name: 'HW 1', description: 'Download /files/555' }],
+      files: [{ id: '555', name: 'handout.pdf', url: '' }],
+      modules: [],
+    });
+    const result = matchMaterialsToAssignments(course);
+    expect(result.get('555')).toBe('canvas-assignment-987');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Announcement body
+// ---------------------------------------------------------------------------
+
+describe('announcement body', () => {
+  it('emits body field in message op when present', () => {
+    const extract = makeExtract({
+      courses: [makeCourse()],
+      announcements: [
+        {
+          title: 'HW Due',
+          course: '101',
+          date: '2026-01-10T00:00:00Z',
+          body: 'Chapter 5 is due Friday',
+        },
+      ],
+    });
+    const ops = transformCanvasExtract(extract, ctx);
+    const msgOp = ops.find((o) => o.entity === 'message');
+    expect(msgOp?.record?.['body']).toBe('Chapter 5 is due Friday');
+  });
+
+  it('falls back to title when body absent', () => {
+    const extract = makeExtract({
+      courses: [makeCourse()],
+      announcements: [{ title: 'Reminder', course: '101' }],
+    });
+    const ops = transformCanvasExtract(extract, ctx);
+    const msgOp = ops.find((o) => o.entity === 'message');
+    expect(msgOp?.record?.['body']).toBe('Reminder');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Events and to-do items are transformed
+// ---------------------------------------------------------------------------
+
+describe('upcoming events and to-do items', () => {
+  it('emits eventSeries ops for upcomingEvents', () => {
+    const extract = makeExtract({
+      upcomingEvents: [{ title: 'Math Test', date: '2026-01-20T09:00:00Z', course: 'AP Math' }],
+    });
+    const ops = transformCanvasExtract(extract, ctx);
+    expect(ops.some((o) => o.entity === 'eventSeries')).toBe(true);
+  });
+
+  it('emits assignment ops with status not_started for toDoItems', () => {
+    const extract = makeExtract({
+      toDoItems: [{ title: 'Read Ch 3', course: 'AP Math', dueDate: '2026-01-18T23:59:00Z' }],
+    });
+    const ops = transformCanvasExtract(extract, ctx);
+    const todoOp = ops.find(
+      (o) => o.entity === 'assignment' && o.record?.['status'] === 'not_started'
+    );
+    expect(todoOp).toBeDefined();
+  });
+});

--- a/packages/scraper-core/src/transformers/canvas/canvas-transformer.ts
+++ b/packages/scraper-core/src/transformers/canvas/canvas-transformer.ts
@@ -113,6 +113,15 @@ function normalizeStatus(raw: string | undefined): string | undefined {
   return 'unknown';
 }
 
+function slugify(s: string): string {
+  return (
+    s
+      .replace(/\s+/g, '-')
+      .replace(/[^a-zA-Z0-9-]/g, '')
+      .toLowerCase() || 'unknown'
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Material-to-Assignment matching (Layers 1 + 2)
 // ---------------------------------------------------------------------------
@@ -122,62 +131,64 @@ function normalizeStatus(raw: string | undefined): string | undefined {
  *   Layer 1 — Canvas module structure (teacher-curated grouping)
  *   Layer 2 — File links in assignment descriptions
  *
- * Returns a Map from file name → assignment array index (as string).
+ * Returns a Map from fileId → native assignment externalId (e.g. "canvas-assignment-987").
+ * Files without a Canvas id are keyed by name and mapped to a name-based externalId.
  */
 export function matchMaterialsToAssignments(course: ICanvasBrowserCourse): Map<string, string> {
+  /** fileKey → nativeAssignmentExternalId */
   const fileToAssignment = new Map<string, string>();
 
-  // Lookup: Canvas file ID → file name
-  const fileIdToName = new Map<string, string>();
+  // Lookup: Canvas file contentId → stable file key (prefer id, fallback to name)
+  const contentIdToFileKey = new Map<string, string>();
   for (const f of course.files) {
-    if (f.id) fileIdToName.set(f.id, f.name);
+    if (f.id) contentIdToFileKey.set(f.id, f.id);
   }
 
-  // Lookup: Canvas assignment ID → assignment array index
-  const assignmentIdToIndex = new Map<string, number>();
+  // Helper: get stable assignment externalId from native Canvas assignment id
+  const assignmentExternalId = (
+    a: ICanvasBrowserCourse['assignments'][number],
+    idx: number
+  ): string => (a.id ? `canvas-assignment-${a.id}` : `canvas-assignment-${course.id}-${idx}`);
+
+  // Lookup: Canvas assignment contentId → assignment externalId
+  const assignmentIdToExtId = new Map<string, string>();
   for (let i = 0; i < course.assignments.length; i++) {
     const a = course.assignments[i]!;
-    if (a.id) assignmentIdToIndex.set(a.id, i);
+    if (a.id) assignmentIdToExtId.set(a.id, assignmentExternalId(a, i));
   }
 
   // --- Layer 1: Module co-occurrence ---
   for (const mod of course.modules) {
     const moduleAssignmentIds: string[] = [];
-    const moduleFileIds: string[] = [];
+    const moduleFileContentIds: string[] = [];
 
     for (const item of mod.items) {
-      if (item.type === 'Assignment' && item.contentId) {
-        moduleAssignmentIds.push(item.contentId);
-      }
-      if (item.type === 'File' && item.contentId) {
-        moduleFileIds.push(item.contentId);
-      }
+      if (item.type === 'Assignment' && item.contentId) moduleAssignmentIds.push(item.contentId);
+      if (item.type === 'File' && item.contentId) moduleFileContentIds.push(item.contentId);
     }
 
-    if (moduleFileIds.length === 0) continue;
+    if (moduleFileContentIds.length === 0) continue;
 
     if (moduleAssignmentIds.length === 1) {
-      // Single assignment in module → all files belong to it
-      const idx = assignmentIdToIndex.get(moduleAssignmentIds[0]!);
-      if (idx !== undefined) {
-        for (const fid of moduleFileIds) {
-          const fname = fileIdToName.get(fid);
-          if (fname && !fileToAssignment.has(fname)) {
-            fileToAssignment.set(fname, String(idx));
+      const extId = assignmentIdToExtId.get(moduleAssignmentIds[0]!);
+      if (extId) {
+        for (const fid of moduleFileContentIds) {
+          const fileKey = contentIdToFileKey.get(fid);
+          if (fileKey && !fileToAssignment.has(fileKey)) {
+            fileToAssignment.set(fileKey, extId);
           }
         }
       }
     } else if (moduleAssignmentIds.length > 1) {
-      // Multiple assignments → assign files to nearest preceding assignment by position
       const sorted = [...mod.items].sort((a, b) => a.position - b.position);
-      let currentIdx: number | undefined;
+      let currentExtId: string | undefined;
       for (const item of sorted) {
         if (item.type === 'Assignment' && item.contentId) {
-          currentIdx = assignmentIdToIndex.get(item.contentId);
-        } else if (item.type === 'File' && item.contentId && currentIdx !== undefined) {
-          const fname = fileIdToName.get(item.contentId);
-          if (fname && !fileToAssignment.has(fname)) {
-            fileToAssignment.set(fname, String(currentIdx));
+          currentExtId = assignmentIdToExtId.get(item.contentId);
+        } else if (item.type === 'File' && item.contentId && currentExtId !== undefined) {
+          const fileKey = contentIdToFileKey.get(item.contentId);
+          if (fileKey && !fileToAssignment.has(fileKey)) {
+            fileToAssignment.set(fileKey, currentExtId);
           }
         }
       }
@@ -189,24 +200,13 @@ export function matchMaterialsToAssignments(course: ICanvasBrowserCourse): Map<s
     const a = course.assignments[i]!;
     if (!a.description) continue;
 
-    // Match Canvas file URLs: /files/{fileId}
+    const extId = assignmentExternalId(a, i);
     const fileIdPattern = /\/files\/(\d+)/g;
     let match: RegExpExecArray | null;
     while ((match = fileIdPattern.exec(a.description)) !== null) {
       const fileId = match[1]!;
-      const fname = fileIdToName.get(fileId);
-      if (fname && !fileToAssignment.has(fname)) {
-        fileToAssignment.set(fname, String(i));
-      }
-    }
-
-    // Match by filename mentioned verbatim in description
-    for (const file of course.files) {
-      const nameNoExt = file.name.replace(/\.[^.]+$/, '');
-      if (nameNoExt.length >= 4 && a.description.includes(file.name)) {
-        if (!fileToAssignment.has(file.name)) {
-          fileToAssignment.set(file.name, String(i));
-        }
+      if (!fileToAssignment.has(fileId)) {
+        fileToAssignment.set(fileId, extId);
       }
     }
   }
@@ -324,7 +324,8 @@ export function transformCanvasExtract(
 
     for (let i = 0; i < course.assignments.length; i++) {
       const a = course.assignments[i]!;
-      const aExtId = `canvas-${course.id}-assignment-${i}`;
+      // Native Canvas assignment ID is stable; fall back to courseId+index only when missing.
+      const aExtId = a.id ? `canvas-assignment-${a.id}` : `canvas-assignment-${course.id}-${i}`;
       const termExternalId = getCanvasTermExternalIdForDueDate(a.dueDate, extract.timestamp || now);
 
       ops.push({
@@ -349,19 +350,24 @@ export function transformCanvasExtract(
     }
 
     // Match course files to assignments via modules + description links
+    // materialMatches: Map<fileId, nativeAssignmentExternalId>
     const materialMatches = matchMaterialsToAssignments(course);
 
-    for (const file of course.files) {
-      const matchedIdx = materialMatches.get(file.name);
-      const assignmentExternalId =
-        matchedIdx !== undefined ? `canvas-${course.id}-assignment-${matchedIdx}` : undefined;
+    for (let fi = 0; fi < course.files.length; fi++) {
+      const file = course.files[fi]!;
+      // Use native Canvas file ID when present; fall back to courseId+slug
+      const fileKey = file.id ?? `name-${slugify(file.name)}`;
+      const assignmentExternalId = materialMatches.get(file.id ?? fileKey);
+      const fileExtId = file.id
+        ? `canvas-file-${file.id}`
+        : `canvas-file-${course.id}-${slugify(file.name)}-${fi}`;
 
       ops.push({
         op: 'upsert',
         entity: 'courseMaterial',
         key: {
           ...baseKey,
-          externalId: `canvas-file-${course.id}-${file.name}`,
+          externalId: fileExtId,
           courseExternalId: courseExtId,
         },
         observedAt: now,
@@ -392,12 +398,50 @@ export function transformCanvasExtract(
       observedAt: now,
       record: {
         subject: ann.title,
-        body: ann.title,
+        body: ann.body || ann.title,
         senderName: 'Canvas',
         senderRole: 'system' as const,
         sentAt: ann.date || now,
         courseExternalId: courseExtId,
         category: 'academic' as const,
+      },
+    });
+  }
+
+  // Upcoming events -> eventSeries (one-off calendar events)
+  for (let i = 0; i < extract.upcomingEvents.length; i++) {
+    const ev = extract.upcomingEvents[i]!;
+    const course = extract.courses.find((c) => c.name === ev.course || c.id === ev.course);
+    const courseExtId = course ? `canvas-course-${course.id}` : undefined;
+    ops.push({
+      op: 'upsert',
+      entity: 'eventSeries',
+      key: { ...baseKey, externalId: `canvas-event-${i}` },
+      observedAt: now,
+      record: {
+        title: ev.title,
+        startAt: ev.date || undefined,
+        courseExternalId: courseExtId,
+        type: 'other' as const,
+      },
+    });
+  }
+
+  // To-do items -> assignment with status not_started
+  for (let i = 0; i < extract.toDoItems.length; i++) {
+    const todo = extract.toDoItems[i]!;
+    const course = extract.courses.find((c) => c.name === todo.course || c.id === todo.course);
+    const courseExtId = course ? `canvas-course-${course.id}` : undefined;
+    ops.push({
+      op: 'upsert',
+      entity: 'assignment',
+      key: { ...baseKey, externalId: `canvas-todo-${i}`, courseExternalId: courseExtId },
+      observedAt: now,
+      record: {
+        title: todo.title,
+        dueAt: todo.dueDate || undefined,
+        status: 'not_started' as const,
+        courseExternalId: courseExtId,
       },
     });
   }

--- a/packages/scraper-core/src/transformers/skyward/skyward-transformer.test.ts
+++ b/packages/scraper-core/src/transformers/skyward/skyward-transformer.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Skyward transformer tests — TDD for _cni-based course IDs, teacher ops from
+ * schedule, attendance courseExternalId, and single-arg extractor contract.
+ */
+
+import { transformSkywardExtract, type ISkywardFullExtract } from '../../index';
+import type { ITransformContext } from '../../types';
+
+const ctx: ITransformContext = {
+  provider: 'skyward',
+  adapterId: 'com.skyward.grade',
+  studentExternalId: 'stu-emma',
+  institutionExternalId: 'inst-test',
+};
+
+function makeExtract(overrides: Partial<ISkywardFullExtract> = {}): ISkywardFullExtract {
+  return {
+    student: 'Emma Lewis',
+    school: 'Central HS',
+    courses: [],
+    missingAssignments: [],
+    assignments: [],
+    attendance: [],
+    schedule: [],
+    timestamp: '2026-01-15T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// native-ids: course externalId uses _cni when present
+// ---------------------------------------------------------------------------
+
+describe('native IDs — Skyward', () => {
+  it('course externalId uses _cni when present', () => {
+    const extract = makeExtract({
+      courses: [
+        {
+          name: 'ALGEBRA 1',
+          period: '1',
+          _cni: 'ABC123',
+          teacher: 'Smith',
+          currentGrade: '90%',
+          grades: {},
+          time: '',
+        },
+      ],
+    });
+    const ops = transformSkywardExtract(extract, ctx);
+    const courseOp = ops.find((o) => o.entity === 'course');
+    expect(courseOp?.key.externalId).toBe('skyward-course-ABC123');
+  });
+
+  it('course externalId falls back to period-slug when _cni absent', () => {
+    const extract = makeExtract({
+      courses: [
+        {
+          name: 'ALGEBRA 1',
+          period: '1',
+          _cni: undefined,
+          teacher: 'Smith',
+          currentGrade: '90%',
+          grades: {},
+          time: '',
+        },
+      ],
+    });
+    const ops = transformSkywardExtract(extract, ctx);
+    const courseOp = ops.find((o) => o.entity === 'course');
+    expect(courseOp?.key.externalId).toBe('skyward-course-1-algebra-1');
+  });
+
+  it('gradeSnapshot externalId matches the course externalId pattern', () => {
+    const extract = makeExtract({
+      courses: [
+        {
+          name: 'ALGEBRA 1',
+          period: '1',
+          _cni: 'XYZ',
+          teacher: '',
+          currentGrade: '85',
+          grades: {},
+          time: '',
+        },
+      ],
+    });
+    const ops = transformSkywardExtract(extract, ctx);
+    const gradeOp = ops.find((o) => o.entity === 'gradeSnapshot');
+    expect(gradeOp?.key.courseExternalId).toBe('skyward-course-XYZ');
+    expect(gradeOp?.record?.['courseExternalId']).toBe('skyward-course-XYZ');
+  });
+
+  it('missing assignment courseExtId respects _cni of matched course', () => {
+    const extract = makeExtract({
+      courses: [
+        {
+          name: 'ALGEBRA 1',
+          period: '1',
+          _cni: 'A1CNI',
+          teacher: '',
+          currentGrade: '',
+          grades: {},
+          time: '',
+        },
+      ],
+      missingAssignments: [
+        {
+          title: 'HW 3',
+          course: 'ALGEBRA 1',
+          period: '1',
+          dueDate: '01/20/2026',
+          teacher: 'Smith',
+        },
+      ],
+    });
+    const ops = transformSkywardExtract(extract, ctx);
+    const assignOp = ops.find((o) => o.entity === 'assignment');
+    expect(assignOp?.key.courseExternalId).toBe('skyward-course-A1CNI');
+    expect(assignOp?.record?.['courseExternalId']).toBe('skyward-course-A1CNI');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// four-pictures: teacher ops from schedule
+// ---------------------------------------------------------------------------
+
+describe('teacher ops — Skyward', () => {
+  it('emits teacher op for each distinct teacher in schedule', () => {
+    const extract = makeExtract({
+      schedule: [
+        {
+          period: '1',
+          course: 'ALGEBRA 1',
+          teacher: 'Smith, John',
+          room: '101',
+          time: '8:00 AM - 8:50 AM',
+        },
+        {
+          period: '2',
+          course: 'ENGLISH 2',
+          teacher: 'Jones, Mary',
+          room: '205',
+          time: '9:00 AM - 9:50 AM',
+        },
+      ],
+    });
+    const ops = transformSkywardExtract(extract, ctx);
+    const teacherOps = ops.filter((o) => o.entity === 'teacher');
+    expect(teacherOps).toHaveLength(2);
+    const names = teacherOps.map((o) => o.record?.['name']).sort();
+    expect(names).toEqual(['Jones, Mary', 'Smith, John']);
+  });
+
+  it('deduplicates the same teacher across periods', () => {
+    const extract = makeExtract({
+      schedule: [
+        { period: '1', course: 'ALGEBRA 1', teacher: 'Smith, John', room: '101', time: '' },
+        { period: '2', course: 'ALGEBRA 2', teacher: 'Smith, John', room: '101', time: '' },
+      ],
+    });
+    const ops = transformSkywardExtract(extract, ctx);
+    const teacherOps = ops.filter((o) => o.entity === 'teacher');
+    expect(teacherOps).toHaveLength(1);
+  });
+
+  it('teacher record includes list of courseExternalIds for their courses', () => {
+    const extract = makeExtract({
+      courses: [
+        {
+          name: 'ALGEBRA 1',
+          period: '1',
+          _cni: 'A1',
+          teacher: '',
+          currentGrade: '',
+          grades: {},
+          time: '',
+        },
+      ],
+      schedule: [
+        { period: '1', course: 'ALGEBRA 1', teacher: 'Smith, John', room: '101', time: '' },
+      ],
+    });
+    const ops = transformSkywardExtract(extract, ctx);
+    const teacherOp = ops.find((o) => o.entity === 'teacher');
+    expect(teacherOp?.record?.['courseExternalIds']).toContain('skyward-course-A1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// four-pictures: attendance courseExternalId via _cni
+// ---------------------------------------------------------------------------
+
+describe('attendance courseExternalId — Skyward', () => {
+  it('attendance op includes courseExternalId when period matches a course with _cni', () => {
+    const extract = makeExtract({
+      courses: [
+        {
+          name: 'ALGEBRA 1',
+          period: '1',
+          _cni: 'A1CNI',
+          teacher: '',
+          currentGrade: '',
+          grades: {},
+          time: '',
+        },
+      ],
+      attendance: [
+        { date: '01/10/2026', period: '1', status: 'Present', reason: '', course: 'ALGEBRA 1' },
+      ],
+    });
+    const ops = transformSkywardExtract(extract, ctx);
+    const attOp = ops.find((o) => o.entity === 'attendanceEvent');
+    expect(attOp?.record?.['courseExternalId']).toBe('skyward-course-A1CNI');
+  });
+
+  it('attendance externalId uses date+period (not array index)', () => {
+    const extract = makeExtract({
+      attendance: [{ date: '01/10/2026', period: '1', status: 'Present', reason: '', course: '' }],
+    });
+    const ops = transformSkywardExtract(extract, ctx);
+    const attOp = ops.find((o) => o.entity === 'attendanceEvent');
+    expect(attOp?.key.externalId).toBe('skyward-attendance-2026-01-10-1');
+    // no raw array index in id — the positive assertion above is sufficient
+  });
+});

--- a/packages/scraper-core/src/transformers/skyward/skyward-transformer.ts
+++ b/packages/scraper-core/src/transformers/skyward/skyward-transformer.ts
@@ -257,10 +257,14 @@ export function transformSkywardExtract(
     if (s.period) scheduleByPeriod.set(s.period, s);
   }
 
+  // Helper: stable course externalId — prefer native _cni, fallback to period+slug
+  const courseExtIdFor = (period: string, name: string, cni?: string): string =>
+    cni ? `skyward-course-${cni}` : `skyward-course-${period}-${slugify(name)}`;
+
   // Courses + grade snapshots (from gradebook)
   for (let i = 0; i < extract.courses.length; i++) {
     const course = extract.courses[i]!;
-    const courseExtId = `skyward-course-${course.period}-${slugify(course.name)}`;
+    const courseExtId = courseExtIdFor(course.period, course.name, course._cni);
     const sched = scheduleByPeriod.get(course.period);
     const { startTime, endTime } = parseTimeRange(sched?.time || course.time);
 
@@ -287,7 +291,7 @@ export function transformSkywardExtract(
         entity: 'gradeSnapshot',
         key: {
           ...baseKey,
-          externalId: `skyward-grade-${course.period}-${slugify(course.name)}`,
+          externalId: `skyward-grade-${course._cni ?? `${course.period}-${slugify(course.name)}`}`,
           courseExternalId: courseExtId,
         },
         observedAt: now,
@@ -329,12 +333,41 @@ export function transformSkywardExtract(
     }
   }
 
+  // Teacher ops from schedule (deduplicated by name)
+  const seenTeachers = new Map<string, { teacher: string; courseExtIds: string[] }>();
+  for (const s of extract.schedule) {
+    if (!s.teacher) continue;
+    const matchingCourse = extract.courses.find((c) => c.period === s.period);
+    const extId = matchingCourse
+      ? courseExtIdFor(matchingCourse.period, matchingCourse.name, matchingCourse._cni)
+      : `skyward-course-${s.period}-${slugify(s.course)}`;
+
+    const existing = seenTeachers.get(s.teacher);
+    if (existing) {
+      existing.courseExtIds.push(extId);
+    } else {
+      seenTeachers.set(s.teacher, { teacher: s.teacher, courseExtIds: [extId] });
+    }
+  }
+  for (const [, { teacher, courseExtIds }] of seenTeachers) {
+    ops.push({
+      op: 'upsert',
+      entity: 'teacher',
+      key: { ...baseKey, externalId: `skyward-teacher-${slugify(teacher)}` },
+      observedAt: now,
+      record: {
+        name: teacher,
+        courseExternalIds: courseExtIds,
+      },
+    });
+  }
+
   // Missing assignments -> assignment (status: missing); set termExternalId for expiration
   for (let i = 0; i < extract.missingAssignments.length; i++) {
     const ma = extract.missingAssignments[i]!;
     const course = extract.courses.find((c) => c.name === ma.course || c.period === ma.period);
     const courseExtId = course
-      ? `skyward-course-${course.period}-${slugify(course.name)}`
+      ? courseExtIdFor(course.period, course.name, course._cni)
       : `skyward-course-${ma.period}-${slugify(ma.course)}`;
     const dueDateIso = ma.dueDate ? parseDate(ma.dueDate) : undefined;
     const termExternalId = getTermExternalIdForDate(dueDateIso);
@@ -365,7 +398,7 @@ export function transformSkywardExtract(
       (c) => c.period === a.period || slugify(c.name) === slugify(a.course)
     );
     const courseExtId = course
-      ? `skyward-course-${course.period}-${slugify(course.name)}`
+      ? courseExtIdFor(course.period, course.name, course._cni)
       : `skyward-course-${a.period}-${slugify(a.course)}`;
     const dueDateIso = a.dueDate ? parseDate(a.dueDate) : undefined;
     const termExtId = getTermExternalIdForDate(dueDateIso ?? undefined);
@@ -397,7 +430,7 @@ export function transformSkywardExtract(
     const a = extract.attendance[i]!;
     const course = extract.courses.find((c) => c.period === a.period || c.name === a.course);
     const courseExtId = course
-      ? `skyward-course-${course.period}-${slugify(course.name)}`
+      ? courseExtIdFor(course.period, course.name, course._cni)
       : undefined;
 
     ops.push({

--- a/packages/scraper-core/src/validator/validator.test.ts
+++ b/packages/scraper-core/src/validator/validator.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Envelope validator tests — join-completeness gates (TDD).
+ */
+
+import { validateEnvelope } from './validator';
+import {
+  SLC_INGEST_SCHEMA_VERSION_V1,
+  type ISlcDeltaOp,
+  type ISlcIngestEnvelopeV1,
+} from '@scholaracle/contracts';
+
+const NOW = '2026-08-14T12:00:00.000Z';
+
+function op(
+  entity: ISlcDeltaOp['entity'],
+  externalId: string,
+  record: Record<string, unknown>,
+  courseExternalId?: string
+): ISlcDeltaOp {
+  return {
+    op: 'upsert',
+    entity,
+    key: {
+      provider: 'canvas',
+      adapterId: 'canvas::default',
+      externalId,
+      ...(courseExternalId ? { courseExternalId } : {}),
+    },
+    observedAt: NOW,
+    record,
+  };
+}
+
+function envelope(ops: readonly ISlcDeltaOp[], provider = 'canvas'): ISlcIngestEnvelopeV1 {
+  return {
+    schemaVersion: SLC_INGEST_SCHEMA_VERSION_V1,
+    run: {
+      runId: 'run-1',
+      startedAt: NOW,
+      provider,
+      adapterId: `${provider}::default`,
+      adapterVersion: 'test@1.0.0',
+      mode: 'delta',
+      timezone: 'America/Chicago',
+    },
+    source: { sourceId: 'src-1', displayName: 'Test' },
+    ops,
+  };
+}
+
+function checkNames(
+  result: ReturnType<typeof validateEnvelope>,
+  severity: 'warning' | 'error'
+): string[] {
+  return result.checks.filter((c) => c.severity === severity).map((c) => c.name);
+}
+
+describe('validateEnvelope join completeness', () => {
+  it('passes a fully joinable LMS envelope with no join warnings', () => {
+    const result = validateEnvelope(
+      envelope([
+        op('course', 'canvas-course-123', {
+          title: 'Algebra 1',
+          teacherName: 'Chang',
+          period: '4',
+          courseCode: 'ALG1',
+        }),
+        op(
+          'assignment',
+          'canvas-assignment-987',
+          { title: '5.A Practice', courseExternalId: 'canvas-course-123' },
+          'canvas-course-123'
+        ),
+        op(
+          'gradeSnapshot',
+          'canvas-grade-123',
+          { courseExternalId: 'canvas-course-123', asOfDate: '2026-08-14' },
+          'canvas-course-123'
+        ),
+        op(
+          'courseMaterial',
+          'canvas-file-555',
+          {
+            title: '5.A.pdf',
+            courseExternalId: 'canvas-course-123',
+            assignmentExternalId: 'canvas-assignment-987',
+            type: 'document',
+          },
+          'canvas-course-123'
+        ),
+      ])
+    );
+
+    expect(result.passed).toBe(true);
+    expect(checkNames(result, 'warning')).not.toEqual(
+      expect.arrayContaining([
+        'join-course-fk',
+        'join-course-exists',
+        'join-assignment-fk',
+        'join-hints-course',
+        'join-role-lms-assignments',
+        'join-role-lms-materials',
+      ])
+    );
+  });
+
+  it('warns when an assignment is missing courseExternalId', () => {
+    const result = validateEnvelope(
+      envelope([
+        op('course', 'canvas-course-123', { title: 'Algebra 1', teacherName: 'Chang' }),
+        op('assignment', 'canvas-assignment-987', { title: 'Homework' }),
+      ])
+    );
+
+    expect(result.passed).toBe(true);
+    expect(checkNames(result, 'warning')).toContain('join-course-fk');
+  });
+
+  it('warns when courseExternalId does not match a course op', () => {
+    const result = validateEnvelope(
+      envelope([
+        op('course', 'canvas-course-123', { title: 'Algebra 1', teacherName: 'Chang' }),
+        op(
+          'assignment',
+          'canvas-assignment-987',
+          { title: 'Homework', courseExternalId: 'canvas-course-999' },
+          'canvas-course-999'
+        ),
+      ])
+    );
+
+    expect(result.passed).toBe(true);
+    expect(checkNames(result, 'warning')).toContain('join-course-exists');
+  });
+
+  it('warns when material.assignmentExternalId does not match an assignment op', () => {
+    const result = validateEnvelope(
+      envelope([
+        op('course', 'canvas-course-123', { title: 'Algebra 1', teacherName: 'Chang' }),
+        op(
+          'assignment',
+          'canvas-assignment-987',
+          { title: 'Homework', courseExternalId: 'canvas-course-123' },
+          'canvas-course-123'
+        ),
+        op(
+          'courseMaterial',
+          'canvas-file-1',
+          {
+            title: 'notes.pdf',
+            courseExternalId: 'canvas-course-123',
+            assignmentExternalId: 'canvas-assignment-missing',
+            type: 'document',
+          },
+          'canvas-course-123'
+        ),
+      ])
+    );
+
+    expect(result.passed).toBe(true);
+    expect(checkNames(result, 'warning')).toContain('join-assignment-fk');
+  });
+
+  it('warns when a course has no teacherName, period, or courseCode', () => {
+    const result = validateEnvelope(
+      envelope([op('course', 'canvas-course-123', { title: 'Algebra 1' })])
+    );
+
+    expect(result.passed).toBe(true);
+    expect(checkNames(result, 'warning')).toContain('join-hints-course');
+  });
+
+  it('warns when an SIS run has courses but no gradeSnapshot', () => {
+    const result = validateEnvelope(
+      envelope(
+        [
+          op('course', 'skyward-course-4-algebra', {
+            title: 'ALGEBRA 1',
+            period: '4',
+            teacherName: 'Chang',
+          }),
+        ],
+        'skyward'
+      )
+    );
+
+    expect(result.passed).toBe(true);
+    expect(checkNames(result, 'warning')).toContain('join-role-sis-grades');
+  });
+
+  it('warns when an LMS run has courses but no assignments', () => {
+    const result = validateEnvelope(
+      envelope([op('course', 'canvas-course-123', { title: 'Algebra 1', teacherName: 'Chang' })])
+    );
+
+    expect(result.passed).toBe(true);
+    expect(checkNames(result, 'warning')).toContain('join-role-lms-assignments');
+  });
+
+  it('warns when an LMS run has courses but no courseMaterial', () => {
+    const result = validateEnvelope(
+      envelope([
+        op('course', 'canvas-course-123', { title: 'Algebra 1', teacherName: 'Chang' }),
+        op(
+          'assignment',
+          'canvas-assignment-1',
+          { title: 'HW', courseExternalId: 'canvas-course-123' },
+          'canvas-course-123'
+        ),
+      ])
+    );
+
+    expect(result.passed).toBe(true);
+    expect(checkNames(result, 'warning')).toContain('join-role-lms-materials');
+  });
+});

--- a/packages/scraper-core/src/validator/validator.ts
+++ b/packages/scraper-core/src/validator/validator.ts
@@ -279,7 +279,149 @@ export function validateEnvelope(envelope: ISlcIngestEnvelopeV1): IEnvelopeValid
     checks.push({ name: 'ops-valid', severity: 'pass', message: 'All ops pass validation' });
   }
 
+  addJoinCompletenessChecks(envelope, checks, entityCounts);
+
   return buildReport(checks, entityCounts);
+}
+
+const COURSE_SCOPED_ENTITIES: ReadonlySet<SlcEntityType> = new Set([
+  'assignment',
+  'gradeSnapshot',
+  'courseMaterial',
+]);
+
+const SIS_PROVIDERS: ReadonlySet<string> = new Set(['skyward', 'aeries']);
+const LMS_PROVIDERS: ReadonlySet<string> = new Set(['canvas', 'google-classroom']);
+
+function courseExternalIdOf(op: ISlcDeltaOp): string | undefined {
+  const fromKey = op.key?.courseExternalId?.trim();
+  if (fromKey) return fromKey;
+  const rec = op.record as Record<string, unknown> | undefined;
+  const fromRecord = rec?.['courseExternalId'];
+  return typeof fromRecord === 'string' && fromRecord.trim() ? fromRecord.trim() : undefined;
+}
+
+/**
+ * Join-graph warnings. These never fail the envelope (`passed` is error-only)
+ * but they tell scraper authors the payload cannot be joined to subjects,
+ * grades, or resources. See docs/CLIENT_SCRAPER_SPEC.md.
+ */
+function addJoinCompletenessChecks(
+  envelope: ISlcIngestEnvelopeV1,
+  checks: IValidationCheck[],
+  entityCounts: Record<string, number>
+): void {
+  const courseIds = new Set<string>();
+  const assignmentIds = new Set<string>();
+  for (const item of envelope.ops) {
+    if (item.op !== 'upsert') continue;
+    if (item.entity === 'course') courseIds.add(item.key.externalId);
+    if (item.entity === 'assignment') assignmentIds.add(item.key.externalId);
+  }
+
+  let missingCourseFk = 0;
+  let danglingCourseFk = 0;
+  let danglingAssignmentFk = 0;
+  let coursesMissingJoinHints = 0;
+
+  for (const item of envelope.ops) {
+    if (item.op !== 'upsert') continue;
+
+    if (COURSE_SCOPED_ENTITIES.has(item.entity)) {
+      const cid = courseExternalIdOf(item);
+      if (!cid) {
+        missingCourseFk += 1;
+      } else if (courseIds.size > 0 && !courseIds.has(cid)) {
+        danglingCourseFk += 1;
+      }
+    }
+
+    if (item.entity === 'courseMaterial') {
+      const rec = item.record as Record<string, unknown> | undefined;
+      const aid = rec?.['assignmentExternalId'];
+      if (
+        typeof aid === 'string' &&
+        aid.trim() &&
+        assignmentIds.size > 0 &&
+        !assignmentIds.has(aid)
+      ) {
+        danglingAssignmentFk += 1;
+      }
+    }
+
+    if (item.entity === 'course') {
+      const rec = item.record as Record<string, unknown> | undefined;
+      const teacher = typeof rec?.['teacherName'] === 'string' && rec['teacherName'].trim();
+      const period = typeof rec?.['period'] === 'string' && rec['period'].trim();
+      const code = typeof rec?.['courseCode'] === 'string' && rec['courseCode'].trim();
+      if (!teacher && !period && !code) {
+        coursesMissingJoinHints += 1;
+      }
+    }
+  }
+
+  if (missingCourseFk > 0) {
+    checks.push({
+      name: 'join-course-fk',
+      severity: 'warning',
+      message: `${missingCourseFk} assignment/grade/material op(s) missing courseExternalId`,
+    });
+  }
+
+  if (danglingCourseFk > 0) {
+    checks.push({
+      name: 'join-course-exists',
+      severity: 'warning',
+      message: `${danglingCourseFk} op(s) reference a courseExternalId with no matching course in this envelope`,
+    });
+  }
+
+  if (danglingAssignmentFk > 0) {
+    checks.push({
+      name: 'join-assignment-fk',
+      severity: 'warning',
+      message: `${danglingAssignmentFk} courseMaterial op(s) reference an assignmentExternalId with no matching assignment in this envelope`,
+    });
+  }
+
+  if (coursesMissingJoinHints > 0) {
+    checks.push({
+      name: 'join-hints-course',
+      severity: 'warning',
+      message: `${coursesMissingJoinHints} course(s) missing teacherName, period, and courseCode — cross-provider subject merge will be weak`,
+    });
+  }
+
+  const provider = envelope.run?.provider ?? '';
+  const courseCount = entityCounts['course'] ?? 0;
+  const gradeCount = entityCounts['gradeSnapshot'] ?? 0;
+  const assignmentCount = entityCounts['assignment'] ?? 0;
+  const materialCount = entityCounts['courseMaterial'] ?? 0;
+
+  if (SIS_PROVIDERS.has(provider) && courseCount > 0 && gradeCount === 0) {
+    checks.push({
+      name: 'join-role-sis-grades',
+      severity: 'warning',
+      message: 'SIS envelope has courses but no gradeSnapshot — official grades cannot be shown',
+    });
+  }
+
+  if (LMS_PROVIDERS.has(provider) && courseCount > 0 && assignmentCount === 0) {
+    checks.push({
+      name: 'join-role-lms-assignments',
+      severity: 'warning',
+      message: 'LMS envelope has courses but no assignments — action board will be empty',
+    });
+  }
+
+  if (LMS_PROVIDERS.has(provider) && courseCount > 0 && materialCount === 0) {
+    checks.push({
+      name: 'join-role-lms-materials',
+      severity: 'warning',
+      message:
+        'LMS envelope has courses but no courseMaterial — resources cannot be joined to subjects',
+    });
+  }
 }
 
 function buildReport(

--- a/packages/web/app/dashboard/install-source/page.tsx
+++ b/packages/web/app/dashboard/install-source/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+/**
+ * SOURCE_INVITE.md §9 — Continue in browser after email tap.
+ */
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { sourceInvitesApi } from '@/lib/api/sourceInvites';
+import { parseInstallSearch } from '@/lib/install/parseInstallSearch';
+import { invitePrefillFromRedeem, storeInvitePrefill } from '@/lib/install/invitePrefill';
+import { SOURCE_INVITE_REDEEM_ERROR } from '@scholaracle/contracts';
+
+export default function InstallSourcePage(): React.ReactElement {
+  const router = useRouter();
+  const [message, setMessage] = useState('Opening your install link…');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = parseInstallSearch(typeof window !== 'undefined' ? window.location.search : '');
+    if (!token) {
+      setError(SOURCE_INVITE_REDEEM_ERROR);
+      return;
+    }
+    void (async (): Promise<void> => {
+      try {
+        const invite = await sourceInvitesApi.redeem(token);
+        storeInvitePrefill(invitePrefillFromRedeem(invite));
+        window.history.replaceState({}, '', '/dashboard/install-source');
+        setMessage(
+          `${invite.displayName} is ready. Open the iOS/Android app or Chrome extension and sign in to the portal there.`
+        );
+      } catch (err: unknown) {
+        const status = typeof err === 'object' && err !== null && 'status' in err ? Number((err as { status: number }).status) : 0;
+        if (status === 401) {
+          const returnTo = `/dashboard/install-source?t=${encodeURIComponent(token)}`;
+          router.push(`/login?redirect=${encodeURIComponent(returnTo)}`);
+          return;
+        }
+        setError(SOURCE_INVITE_REDEEM_ERROR);
+      }
+    })();
+  }, [router]);
+
+  return (
+    <div className="mx-auto max-w-lg space-y-4">
+      <h1 className="text-xl font-semibold">Install a school portal</h1>
+      {error ? <p className="text-sm text-destructive">{error}</p> : <p className="text-sm text-muted-foreground">{message}</p>}
+    </div>
+  );
+}

--- a/packages/web/app/dashboard/layout.tsx
+++ b/packages/web/app/dashboard/layout.tsx
@@ -24,15 +24,15 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   const studentIdFromPath = useMemo(() => getStudentIdFromPath(pathname ?? ''), [pathname]);
 
   useEffect(() => {
-    // Initialize auth token
     authApi.initialize();
-
-    // Check if user is authenticated
     const token = authApi.getToken();
     if (!token) {
-      router.push('/login');
+      const search = typeof window !== 'undefined' ? window.location.search : '';
+      const path = `${pathname ?? '/dashboard'}${search}`;
+      const dest = path.startsWith('/') ? path : '/dashboard';
+      router.push(`/login?redirect=${encodeURIComponent(dest)}`);
     }
-  }, [router]);
+  }, [router, pathname]);
 
   const handleLogout = async () => {
     await authApi.logout();

--- a/packages/web/components/dashboard/AddStudentWizard.tsx
+++ b/packages/web/components/dashboard/AddStudentWizard.tsx
@@ -69,12 +69,6 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
   const [bundle, setBundle] = useState<IBundleConnection[]>([]);
   const [currentIntegration, setCurrentIntegration] = useState<IIntegration | null>(null);
 
-  // Credentials for the current connection
-  const [, setAuthType] = useState<'api' | 'login'>('api');
-  const [, setAccessToken] = useState('');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-
   // New provider: open ConnectProviderWizard; after download or add-to-bundle we update state
   const [connectProviderWizardOpen, setConnectProviderWizardOpen] = useState(false);
   const [bundleDownloading, setBundleDownloading] = useState(false);
@@ -96,36 +90,7 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
   // ---------------------------------------------------------------------------
 
   const resetCredentials = () => {
-    setAuthType('api');
-    setAccessToken('');
-    setUsername('');
-    setPassword('');
     setTestResult(null);
-    setTestingConnection(false);
-  };
-
-  const handleTestConnection = async () => {
-    if (!currentIntegration) return;
-    const providerInfo = findProviderById(currentIntegration.provider);
-    if (!providerInfo) return;
-
-    setTestingConnection(true);
-    setTestResult(null);
-
-    const credPayload: { authType: 'login'; username?: string; password?: string } = {
-      authType: 'login',
-    };
-    if (username.trim()) credPayload.username = username.trim();
-    if (password) credPayload.password = password;
-
-    const result = await integrationsApi.testConnection({
-      provider: currentIntegration.provider,
-      adapterId: currentIntegration.adapterId,
-      baseUrl: currentIntegration.portalBaseUrl,
-      credentials: credPayload,
-    });
-
-    setTestResult(result);
     setTestingConnection(false);
   };
 
@@ -143,7 +108,6 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
     setCreatedStudentId(null);
     setCreatedStudentName('');
   };
-
   const handleClose = () => {
     resetAll();
     onClose();
@@ -205,9 +169,10 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
     setError(null);
     setSubmitting(true);
 
-    let credentials: IAssignStudentCredentials | undefined;
-    if (!skipCredentials && username.trim() && password) {
-      credentials = { authType: 'login', username: username.trim(), password };
+    const credentials: IAssignStudentCredentials | undefined = undefined;
+
+    if (skipCredentials) {
+      // Link without credentials; user can add them later from the app or extension.
     }
 
     try {
@@ -239,12 +204,9 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
     }
   };
 
-  const handleSkipCredentials = () => handleConnect(true);
-
   // ---------------------------------------------------------------------------
   // Step 4 – Done
   // ---------------------------------------------------------------------------
-
   const handleFinish = () => {
     onStudentAdded?.();
     handleClose();
@@ -269,7 +231,6 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
     setCreatedStudentId(null);
     setCreatedStudentName('');
   };
-
   const handleRemoveFromBundle = (id: string) => {
     setBundle((b) => b.filter((c) => c.id !== id));
   };
@@ -288,8 +249,6 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
       loginUrl: c.loginUrl,
       scraperId: c.scraperId,
       credentials: {
-        username: c.username,
-        password: c.password,
         studentNameHint: c.studentNameHint,
       },
     }));
@@ -627,7 +586,7 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
               </Button>
 
               <p className="text-sm text-muted-foreground">
-                Connect a new school platform by downloading a script. You&apos;ll pick your platform, enter your school login, and run the script on your computer to sync grades — same flow as the standalone setup wizard.
+                Connect a new school platform. Use the iOS app, browser extension, or the local CLI to run the scraper on your computer — your school login stays on your device.
               </p>
 
               <Button
@@ -640,6 +599,7 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
 
               <ConnectProviderWizard
                 open={connectProviderWizardOpen}
+                studentId={createdStudentId ?? undefined}
                 onClose={() => setConnectProviderWizardOpen(false)}
                 onConnectionReady={(connection) => {
                   setBundle((b) => [...b, connection]);
@@ -675,7 +635,7 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
 
                 <div className="text-sm">
                   <p>
-                    Enter <strong>{createdStudentName}</strong>&apos;s credentials for{' '}
+                    Connecting <strong>{createdStudentName}</strong> to{' '}
                     <strong>{currentIntegration.displayName}</strong>.
                   </p>
                 </div>
@@ -702,44 +662,29 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
                   </div>
                 )}
 
-                <div className="space-y-3">
-                  <div className="space-y-2">
-                    <Label htmlFor="wizard-username">Username</Label>
-                    <Input
-                      id="wizard-username"
-                      type="text"
-                      placeholder="Student's portal username"
-                      value={username}
-                      onChange={(e) => {
-                        setUsername(e.target.value);
-                        setAuthType('login');
-                      }}
-                      disabled={submitting}
-                      data-testid="wizard-credentials-username"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="wizard-password">Password</Label>
-                    <Input
-                      id="wizard-password"
-                      type="password"
-                      placeholder="Student's portal password"
-                      value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value);
-                        setAuthType('login');
-                      }}
-                      disabled={submitting}
-                      data-testid="wizard-credentials-password"
-                    />
-                  </div>
-                </div>
-
-                {providerInfo?.credentialHelp.note && (
-                  <p className="text-xs text-muted-foreground bg-muted/50 rounded-md p-2">
-                    {providerInfo.credentialHelp.note}
+                <div className="rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950 p-4 space-y-2">
+                  <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
+                    School portal credentials stay on your device
                   </p>
-                )}
+                  <p className="text-sm text-amber-800 dark:text-amber-200">
+                    {currentIntegration.displayName} uses browser-based extraction. Your student&apos;s
+                    school login is never uploaded to Scholarmancy.
+                  </p>
+                  <ul className="text-sm text-amber-800 dark:text-amber-200 list-disc list-inside space-y-1">
+                    <li>
+                      <strong>iOS app</strong> — tap Add Source inside the Scholarmancy app
+                    </li>
+                    <li>
+                      <strong>Browser extension</strong> — connect from the school&apos;s portal page
+                    </li>
+                    <li>
+                      <strong>Local CLI</strong> — run{' '}
+                      <code className="bg-amber-100 dark:bg-amber-900 rounded px-1">
+                        npx scholaracle-scraper run
+                      </code>
+                    </li>
+                  </ul>
+                </div>
 
                 {/* Test Connection result */}
                 {testResult && (
@@ -767,35 +712,15 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
                 )}
 
                 <div className="flex gap-2 pt-2 flex-wrap">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={handleTestConnection}
-                    disabled={testingConnection || submitting}
-                    data-testid="wizard-test-connection"
-                  >
-                    {testingConnection ? 'Testing...' : 'Test Connection'}
-                  </Button>
                   <div className="flex gap-2 ml-auto">
                     <Button
                       type="button"
-                      variant="ghost"
                       size="sm"
-                      className="text-muted-foreground"
-                      onClick={handleSkipCredentials}
-                      disabled={submitting}
-                    >
-                      Skip credentials
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      onClick={() => handleConnect(false)}
+                      onClick={() => handleConnect(true)}
                       disabled={submitting}
                       data-testid="wizard-connect-submit"
                     >
-                      {submitting ? 'Connecting...' : 'Connect'}
+                      {submitting ? 'Connecting...' : 'Continue without credentials'}
                     </Button>
                   </div>
                 </div>

--- a/packages/web/components/dashboard/AddStudentWizard.tsx
+++ b/packages/web/components/dashboard/AddStudentWizard.tsx
@@ -72,7 +72,6 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
   // New provider: open ConnectProviderWizard; after download or add-to-bundle we update state
   const [connectProviderWizardOpen, setConnectProviderWizardOpen] = useState(false);
   const [bundleDownloading, setBundleDownloading] = useState(false);
-  const [testingConnection, setTestingConnection] = useState(false);
   const [testResult, setTestResult] = useState<ITestConnectionResult | null>(null);
 
   // Created student tracking
@@ -91,7 +90,6 @@ export function AddStudentWizard({ open, onClose, onStudentAdded }: AddStudentWi
 
   const resetCredentials = () => {
     setTestResult(null);
-    setTestingConnection(false);
   };
 
   const resetAll = () => {

--- a/packages/web/components/dashboard/integrations/AssignStudentSheet.tsx
+++ b/packages/web/components/dashboard/integrations/AssignStudentSheet.tsx
@@ -39,10 +39,7 @@ export function AssignStudentSheet({
   onAssigned,
 }: AssignStudentSheetProps) {
   const [selectedStudentId, setSelectedStudentId] = useState<string>('');
-  const [authType, setAuthType] = useState<'api' | 'login'>('api');
   const [accessToken, setAccessToken] = useState('');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -51,10 +48,7 @@ export function AssignStudentSheet({
 
   const handleClose = () => {
     setSelectedStudentId('');
-    setAuthType('api');
     setAccessToken('');
-    setUsername('');
-    setPassword('');
     setError(null);
     onClose();
   };
@@ -68,10 +62,8 @@ export function AssignStudentSheet({
     setSubmitting(true);
 
     let credentials: IAssignStudentCredentials | undefined;
-    if (authType === 'api' && accessToken.trim()) {
+    if (accessToken.trim()) {
       credentials = { authType: 'api', accessToken: accessToken.trim() };
-    } else if (authType === 'login' && username.trim() && password) {
-      credentials = { authType: 'login', username: username.trim(), password };
     }
 
     try {
@@ -99,7 +91,7 @@ export function AssignStudentSheet({
         </SheetHeader>
         <div className="py-4 space-y-4">
           <p className="text-sm text-muted-foreground">
-            Choose a student and optionally add their credentials for this provider.
+            Choose a student and optionally add their API access token for this provider.
           </p>
 
           <div className="space-y-2">
@@ -122,52 +114,18 @@ export function AssignStudentSheet({
           </div>
 
           <div className="space-y-2">
-            <Label>Credentials (optional — can add later)</Label>
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                variant={authType === 'api' ? 'default' : 'outline'}
-                size="sm"
-                onClick={() => setAuthType('api')}
-              >
-                API token
-              </Button>
-              <Button
-                type="button"
-                variant={authType === 'login' ? 'default' : 'outline'}
-                size="sm"
-                onClick={() => setAuthType('login')}
-              >
-                Portal login
-              </Button>
-            </div>
-            {authType === 'api' && (
-              <Input
-                type="password"
-                placeholder="Access token"
-                value={accessToken}
-                onChange={(e) => setAccessToken(e.target.value)}
-                data-testid="assign-credentials-token"
-              />
-            )}
-            {authType === 'login' && (
-              <div className="space-y-2">
-                <Input
-                  type="text"
-                  placeholder="Username"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  data-testid="assign-credentials-username"
-                />
-                <Input
-                  type="password"
-                  placeholder="Password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  data-testid="assign-credentials-password"
-                />
-              </div>
-            )}
+            <Label>API access token (optional — can add later)</Label>
+            <Input
+              type="password"
+              placeholder="Access token"
+              value={accessToken}
+              onChange={(e) => setAccessToken(e.target.value)}
+              data-testid="assign-credentials-token"
+            />
+            <p className="text-xs text-muted-foreground">
+              For Canvas/Skyward/Aeries portal login, use the iOS app, browser extension, or{' '}
+              <code>npx scholaracle-scraper run</code> on your computer.
+            </p>
           </div>
 
           {error && <p className="text-sm text-destructive">{error}</p>}

--- a/packages/web/components/dashboard/integrations/ConnectProviderWizard.tsx
+++ b/packages/web/components/dashboard/integrations/ConnectProviderWizard.tsx
@@ -20,6 +20,8 @@ import {
   type IProviderDescriptor,
 } from '@/lib/providers';
 import type { IBundleConnection } from './bundle-types';
+import { sourceInvitesApi } from '@/lib/api/sourceInvites';
+import { isSourceInviteProvider } from '@scholaracle/contracts';
 
 interface JobStep {
   name: string;
@@ -47,6 +49,8 @@ export interface ConnectProviderWizardProps {
   onConnectionReady?: (connection: IBundleConnection) => void;
   /** When provided without onConnectionReady, wizard ends at download step and calls this after download. */
   onAdded?: () => void;
+  /** When set, show Email me an install link for builtin portals. */
+  studentId?: string;
 }
 
 type Step = 'platform' | 'credentials' | 'generating' | 'download' | 'added';
@@ -61,15 +65,13 @@ const OTHER_PLATFORM: Pick<IProviderDescriptor, 'id' | 'name' | 'description' | 
   urlPlaceholder: 'https://...',
 };
 
-export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdded }: ConnectProviderWizardProps) {
+export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdded, studentId }: ConnectProviderWizardProps) {
   const [step, setStep] = useState<Step>('platform');
   const [portalUrl, setPortalUrl] = useState('');
   const [detectedProvider, setDetectedProvider] = useState<IProviderDescriptor | undefined>();
   const [selectedProvider, setSelectedProvider] = useState<IProviderDescriptor | typeof OTHER_PLATFORM | null>(null);
   const [customPlatformName, setCustomPlatformName] = useState('');
   const [studentNameHint, setStudentNameHint] = useState('');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
   const [scraperId, setScraperId] = useState<string | null>(null);
   const [jobId, setJobId] = useState<string | null>(null);
   const [jobStatus, setJobStatus] = useState<GenerateStatusResponse | null>(null);
@@ -77,6 +79,7 @@ export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdde
   const [generatedCode, setGeneratedCode] = useState<string | null>(null);
   const [showCode, setShowCode] = useState(false);
   const [pendingConnection, setPendingConnection] = useState<{ scraperId: string | null; platformName: string; loginUrl: string } | null>(null);
+  const [emailStatus, setEmailStatus] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const allProviders = getAllProviders();
@@ -92,8 +95,6 @@ export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdde
     setSelectedProvider(null);
     setCustomPlatformName('');
     setStudentNameHint('');
-    setUsername('');
-    setPassword('');
     setScraperId(null);
     setJobId(null);
     setJobStatus(null);
@@ -101,6 +102,7 @@ export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdde
     setGeneratedCode(null);
     setShowCode(false);
     setPendingConnection(null);
+    setEmailStatus(null);
   }, [open]);
 
   useEffect(() => {
@@ -163,8 +165,6 @@ export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdde
       platformId,
       platformName: pendingConnection.platformName,
       loginUrl: pendingConnection.loginUrl,
-      username,
-      password,
       studentNameHint: studentNameHint.trim() || undefined,
       scraperId: pendingConnection.scraperId,
       generationStatus: 'ready',
@@ -172,7 +172,7 @@ export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdde
     };
     onConnectionReady(connection);
     setPendingConnection(null);
-  }, [step, pendingConnection, onConnectionReady, selectedProvider, username, password, studentNameHint]);
+  }, [step, pendingConnection, onConnectionReady, selectedProvider, studentNameHint]);
 
   const handleClose = () => {
     if (pollRef.current) {
@@ -185,8 +185,6 @@ export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdde
     setSelectedProvider(null);
     setCustomPlatformName('');
     setStudentNameHint('');
-    setUsername('');
-    setPassword('');
     setScraperId(null);
     setJobId(null);
     setJobStatus(null);
@@ -218,11 +216,7 @@ export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdde
     }
     const requireStudentName = !onConnectionReady;
     if (requireStudentName && !studentNameHint.trim()) {
-      setError('Please fill in student name, username, and password.');
-      return;
-    }
-    if (!username.trim() || !password) {
-      setError('Please fill in username and password.');
+      setError('Please fill in student name.');
       return;
     }
 
@@ -238,8 +232,6 @@ export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdde
           platformId,
           platformName,
           loginUrl,
-          username,
-          password,
           studentNameHint: studentNameHint.trim() || undefined,
           scraperId: null,
           generationStatus: 'ready',
@@ -306,7 +298,7 @@ export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdde
         body: JSON.stringify({
           os: detectedOS,
           ...(scraperId ? { scraperId } : { platform: platformName, url: loginUrl }),
-          credentials: { studentName: studentNameHint.trim() || 'default', username: username.trim(), password, studentNameHint: studentNameHint.trim() || undefined },
+          credentials: { studentNameHint: studentNameHint.trim() || undefined },
         }),
       });
       if (!response.ok) throw new Error('Download failed');
@@ -331,6 +323,28 @@ export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdde
 
   const displayName = selectedProvider?.id === 'other' ? customPlatformName : selectedProvider?.name;
   const isReference = selectedProvider && selectedProvider.id !== 'other' && (selectedProvider as IProviderDescriptor).available;
+
+  const handleEmailInstallLink = async (): Promise<void> => {
+    if (!studentId || !selectedProvider || !isSourceInviteProvider(selectedProvider.id)) return;
+    if (!portalUrl.trim()) {
+      setError('Please enter the school portal URL.');
+      return;
+    }
+    setError(null);
+    setEmailStatus(null);
+    try {
+      const result = await sourceInvitesApi.issue({
+        studentId,
+        provider: selectedProvider.id,
+        portalBaseUrl: portalUrl.trim(),
+      });
+      setEmailStatus(
+        `We emailed ${result.emailedTo}. Open it on your phone or in Chrome — same link.`
+      );
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Could not send install link');
+    }
+  };
 
   return (
     <Dialog open={open} onOpenChange={(open) => !open && handleClose()}>
@@ -442,9 +456,9 @@ export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdde
             </div>
 
             <div className="border-t pt-4 space-y-3">
-              <p className="text-sm font-medium">Your school login</p>
+              <p className="text-sm font-medium">Student name hint (optional)</p>
               <p className="text-xs text-muted-foreground">
-                Credentials are baked into the downloaded script and never stored on our servers.
+                School portal credentials stay on your device and are entered at runtime — never uploaded to Scholarmancy.
               </p>
               <div className="space-y-2">
                 <Label htmlFor="student-name-hint">
@@ -458,33 +472,23 @@ export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdde
                   data-testid="connect-provider-student-name-hint"
                 />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="cred-username">Username</Label>
-                <Input
-                  id="cred-username"
-                  placeholder="e.g., parent@email.com"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  data-testid="connect-provider-username"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="cred-password">Password</Label>
-                <Input
-                  id="cred-password"
-                  type="password"
-                  placeholder="Your school portal password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  data-testid="connect-provider-password"
-                />
-              </div>
             </div>
 
             {error && <p className="text-sm text-destructive">{error}</p>}
+            {emailStatus && <p className="text-sm text-muted-foreground">{emailStatus}</p>}
 
             <div className="flex gap-2 pt-2">
               <Button variant="outline" onClick={() => setStep('platform')}>Back</Button>
+              {studentId && selectedProvider && isSourceInviteProvider(selectedProvider.id) && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void handleEmailInstallLink()}
+                  data-testid="button-email-install-link"
+                >
+                  Email me an install link
+                </Button>
+              )}
               <Button onClick={handleCredentialsNext} data-testid="connect-provider-continue">
                 {isReference ? 'Continue' : 'Generate Scraper'}
               </Button>
@@ -567,7 +571,7 @@ export function ConnectProviderWizard({ open, onClose, onConnectionReady, onAdde
                 <li>Offers to run automatically 3x daily</li>
               </ol>
               <p className="mt-2">
-                Your login credentials are stored in the downloaded file and never leave your computer.
+                When the script runs, it will prompt you for your school login. Your credentials are never uploaded to Scholarmancy.
               </p>
             </div>
 

--- a/packages/web/components/dashboard/integrations/ConnectToIntegrationSheet.tsx
+++ b/packages/web/components/dashboard/integrations/ConnectToIntegrationSheet.tsx
@@ -24,10 +24,7 @@ export function ConnectToIntegrationSheet({
   onConnected,
 }: ConnectToIntegrationSheetProps) {
   const [selected, setSelected] = useState<IIntegration | null>(null);
-  const [authType, setAuthType] = useState<'api' | 'login'>('api');
   const [accessToken, setAccessToken] = useState('');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -36,10 +33,7 @@ export function ConnectToIntegrationSheet({
 
   const handleClose = () => {
     setSelected(null);
-    setAuthType('api');
     setAccessToken('');
-    setUsername('');
-    setPassword('');
     setError(null);
     onClose();
   };
@@ -50,10 +44,8 @@ export function ConnectToIntegrationSheet({
     setSubmitting(true);
 
     let credentials: IAssignStudentCredentials | undefined;
-    if (authType === 'api' && accessToken.trim()) {
+    if (accessToken.trim()) {
       credentials = { authType: 'api', accessToken: accessToken.trim() };
-    } else if (authType === 'login' && username.trim() && password) {
-      credentials = { authType: 'login', username: username.trim(), password };
     }
 
     try {
@@ -107,49 +99,17 @@ export function ConnectToIntegrationSheet({
             <>
               <p className="text-sm font-medium">{selected.displayName}</p>
               <div className="space-y-2">
-                <Label>Credentials (optional — can add later)</Label>
-                <div className="flex gap-2">
-                  <Button
-                    type="button"
-                    variant={authType === 'api' ? 'default' : 'outline'}
-                    size="sm"
-                    onClick={() => setAuthType('api')}
-                  >
-                    API token
-                  </Button>
-                  <Button
-                    type="button"
-                    variant={authType === 'login' ? 'default' : 'outline'}
-                    size="sm"
-                    onClick={() => setAuthType('login')}
-                  >
-                    Portal login
-                  </Button>
-                </div>
-                {authType === 'api' && (
-                  <Input
-                    type="password"
-                    placeholder="Access token"
-                    value={accessToken}
-                    onChange={(e) => setAccessToken(e.target.value)}
-                  />
-                )}
-                {authType === 'login' && (
-                  <div className="space-y-2">
-                    <Input
-                      type="text"
-                      placeholder="Username"
-                      value={username}
-                      onChange={(e) => setUsername(e.target.value)}
-                    />
-                    <Input
-                      type="password"
-                      placeholder="Password"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                    />
-                  </div>
-                )}
+                <Label>API access token (optional — can add later)</Label>
+                <Input
+                  type="password"
+                  placeholder="Access token"
+                  value={accessToken}
+                  onChange={(e) => setAccessToken(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  For Canvas/Skyward/Aeries portal login, use the iOS app, browser extension, or{' '}
+                  <code>npx scholaracle-scraper run</code> on your computer.
+                </p>
               </div>
               {error && <p className="text-sm text-destructive">{error}</p>}
               <div className="flex gap-2">

--- a/packages/web/components/dashboard/integrations/SelfHostedScraperCard.tsx
+++ b/packages/web/components/dashboard/integrations/SelfHostedScraperCard.tsx
@@ -38,8 +38,6 @@ export function SelfHostedScraperCard() {
         loginUrl: c.loginUrl,
         scraperId: c.scraperId,
         credentials: {
-          username: c.username,
-          password: c.password,
           studentNameHint: c.studentNameHint,
         },
       }));

--- a/packages/web/components/dashboard/integrations/bundle-types.ts
+++ b/packages/web/components/dashboard/integrations/bundle-types.ts
@@ -8,8 +8,6 @@ export interface IBundleConnection {
   readonly platformId: string;
   readonly platformName: string;
   readonly loginUrl: string;
-  readonly username: string;
-  readonly password: string;
   /** Optional hint when the portal only shows one student's data. */
   readonly studentNameHint?: string;
   readonly scraperId: string | null;
@@ -23,8 +21,6 @@ export interface IBundleConnectionPayload {
   readonly loginUrl: string;
   readonly scraperId: string | null;
   readonly credentials: {
-    readonly username: string;
-    readonly password: string;
     readonly studentNameHint?: string;
   };
 }

--- a/packages/web/components/dashboard/students/ConnectSourceWizard.tsx
+++ b/packages/web/components/dashboard/students/ConnectSourceWizard.tsx
@@ -12,6 +12,8 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import type { IAddSourceRequest, ISourceCredentialsRequest } from '@/lib/api/sources';
+import { sourceInvitesApi } from '@/lib/api/sourceInvites';
+import { isSourceInviteProvider } from '@scholaracle/contracts';
 
 export interface ConnectSourceWizardProps {
   open: boolean;
@@ -42,6 +44,7 @@ export function ConnectSourceWizard({
   const [schedule, setSchedule] = useState<IAddSourceRequest['schedule']>('every_6h');
   const [dataTypes, setDataTypes] = useState<string[]>(['grades', 'assignments', 'calendar']);
   const [submitting, setSubmitting] = useState(false);
+  const [emailStatus, setEmailStatus] = useState<string | null>(null);
 
   const handleClose = () => {
     setStep(1);
@@ -52,6 +55,8 @@ export function ConnectSourceWizard({
     setAccessToken('');
     setSchedule('every_6h');
     setDataTypes(['grades', 'assignments', 'calendar']);
+    setSubmitting(false);
+    setEmailStatus(null);
     onClose();
   };
 
@@ -59,6 +64,28 @@ export function ConnectSourceWizard({
     if (!p.available) return;
     setProvider(p);
     setStep(2);
+  };
+
+  const handleEmailInstallLink = async (): Promise<void> => {
+    if (!provider || !isSourceInviteProvider(provider.id)) return;
+    if (!portalBaseUrl.trim()) return;
+    setSubmitting(true);
+    setEmailStatus(null);
+    try {
+      const result = await sourceInvitesApi.issue({
+        studentId,
+        provider: provider.id,
+        portalBaseUrl: portalBaseUrl.trim(),
+        ...(displayName.trim() ? { displayName: displayName.trim() } : {}),
+      });
+      setEmailStatus(
+        `We emailed ${result.emailedTo}. Open it on your phone or in Chrome — same link.`
+      );
+    } catch (err: unknown) {
+      setEmailStatus(err instanceof Error ? err.message : 'Could not send install link');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const handleStep2Next = () => {
@@ -158,6 +185,19 @@ export function ConnectSourceWizard({
                   Next
                 </Button>
               </div>
+              {provider && isSourceInviteProvider(provider.id) && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  disabled={submitting || !portalBaseUrl.trim()}
+                  onClick={() => void handleEmailInstallLink()}
+                  data-testid="button-email-install-link"
+                >
+                  Email me an install link
+                </Button>
+              )}
+              {emailStatus && <p className="text-sm text-muted-foreground">{emailStatus}</p>}
             </>
           )}
 

--- a/packages/web/components/dashboard/students/SourceCredentialsSheet.tsx
+++ b/packages/web/components/dashboard/students/SourceCredentialsSheet.tsx
@@ -12,39 +12,35 @@ export interface SourceCredentialsSheetProps {
   studentId: string;
   sourceId: string;
   displayName: string;
+  provider?: string;
   onClose: () => void;
   onSaved?: () => void;
 }
+
+const HTML_PORTAL_PROVIDERS = new Set(['canvas', 'skyward', 'aeries', 'powerschool', 'infinite_campus', 'genesis']);
 
 export function SourceCredentialsSheet({
   open,
   studentId,
   sourceId,
   displayName,
+  provider,
   onClose,
   onSaved,
 }: SourceCredentialsSheetProps) {
-  const [authType, setAuthType] = useState<'api' | 'login'>('api');
   const [accessToken, setAccessToken] = useState('');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const isHtmlPortal = provider ? HTML_PORTAL_PROVIDERS.has(provider.toLowerCase()) : false;
+
   const handleSave = async () => {
     setError(null);
-    const creds: ISourceCredentialsRequest =
-      authType === 'api'
-        ? { authType: 'api', accessToken: accessToken.trim() }
-        : { authType: 'login', username: username.trim(), password };
-    if (authType === 'api' && !creds.accessToken?.trim()) {
+    if (!accessToken.trim()) {
       setError('Enter an access token');
       return;
     }
-    if (authType === 'login' && (!creds.username?.trim() || !password)) {
-      setError('Enter username and password');
-      return;
-    }
+    const creds: ISourceCredentialsRequest = { authType: 'api', accessToken: accessToken.trim() };
     setSubmitting(true);
     const ok = await sourcesApi.setCredentials(studentId, sourceId, creds);
     setSubmitting(false);
@@ -63,80 +59,65 @@ export function SourceCredentialsSheet({
           <SheetTitle>Credentials for {displayName}</SheetTitle>
         </SheetHeader>
         <div className="py-4 space-y-4">
-          <p className="text-sm text-muted-foreground">
-            Add API credentials or portal login so we can sync data. Stored securely.
-          </p>
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              variant={authType === 'api' ? 'default' : 'outline'}
-              size="sm"
-              onClick={() => setAuthType('api')}
-              data-testid="credentials-type-api"
-            >
-              API / access token
-            </Button>
-            <Button
-              type="button"
-              variant={authType === 'login' ? 'default' : 'outline'}
-              size="sm"
-              onClick={() => setAuthType('login')}
-              data-testid="credentials-type-login"
-            >
-              Log in to portal
-            </Button>
-          </div>
-          {authType === 'api' && (
-            <div className="space-y-2">
-              <Label htmlFor="cred-access-token">Access token</Label>
-              <Input
-                id="cred-access-token"
-                type="password"
-                placeholder="Paste your API or access token"
-                value={accessToken}
-                onChange={(e) => setAccessToken(e.target.value)}
-                data-testid="input-cred-access-token"
-              />
+          {isHtmlPortal ? (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950 p-4 space-y-2">
+              <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
+                Use the mobile app, browser extension, or local CLI
+              </p>
+              <p className="text-sm text-amber-800 dark:text-amber-200">
+                {displayName} uses browser-based extraction. School portal credentials stay on your
+                device and are never sent to Scholarmancy servers.
+              </p>
+              <ul className="text-sm text-amber-800 dark:text-amber-200 list-disc list-inside space-y-1">
+                <li>
+                  <strong>iOS app</strong> — tap Add Source inside the Scholarmancy app
+                </li>
+                <li>
+                  <strong>Browser extension</strong> — connect from your school&apos;s portal page
+                </li>
+                <li>
+                  <strong>Local CLI</strong> — run{' '}
+                  <code className="bg-amber-100 dark:bg-amber-900 rounded px-1">
+                    npx scholaracle-scraper run
+                  </code>
+                </li>
+              </ul>
             </div>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground">Add an API access token for this source.</p>
+              <div className="space-y-2">
+                <Label htmlFor="cred-access-token">Access token</Label>
+                <Input
+                  id="cred-access-token"
+                  type="password"
+                  placeholder="Paste your API or access token"
+                  value={accessToken}
+                  onChange={(e) => setAccessToken(e.target.value)}
+                  data-testid="input-cred-access-token"
+                />
+              </div>
+              {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+              <div className="flex gap-2">
+                <Button type="button" variant="outline" onClick={onClose}>
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={submitting}
+                  data-testid="button-save-credentials"
+                >
+                  {submitting ? 'Saving...' : 'Save credentials'}
+                </Button>
+              </div>
+            </>
           )}
-          {authType === 'login' && (
-            <div className="space-y-2">
-              <Label htmlFor="cred-username">Username</Label>
-              <Input
-                id="cred-username"
-                type="text"
-                autoComplete="username"
-                placeholder="Portal username"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-                data-testid="input-cred-username"
-              />
-              <Label htmlFor="cred-password">Password</Label>
-              <Input
-                id="cred-password"
-                type="password"
-                autoComplete="current-password"
-                placeholder="Portal password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                data-testid="input-cred-password"
-              />
-            </div>
+          {isHtmlPortal && (
+            <Button type="button" variant="outline" onClick={onClose} className="w-full">
+              Close
+            </Button>
           )}
-          {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
-          <div className="flex gap-2">
-            <Button type="button" variant="outline" onClick={onClose}>
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              onClick={handleSave}
-              disabled={submitting}
-              data-testid="button-save-credentials"
-            >
-              {submitting ? 'Saving...' : 'Save credentials'}
-            </Button>
-          </div>
         </div>
       </SheetContent>
     </Sheet>

--- a/packages/web/lib/api/integrations.ts
+++ b/packages/web/lib/api/integrations.ts
@@ -43,10 +43,8 @@ export interface IIntegrationLinkedStudent {
 }
 
 export interface IAssignStudentCredentials {
-  readonly authType: 'api' | 'login';
+  readonly authType: 'api';
   readonly accessToken?: string;
-  readonly username?: string;
-  readonly password?: string;
   readonly baseUrl?: string;
 }
 
@@ -59,10 +57,8 @@ export interface ITestConnectionRequest {
   readonly adapterId: string;
   readonly baseUrl?: string;
   readonly credentials: {
-    readonly authType: 'api' | 'login' | 'oauth2' | 'api-key';
+    readonly authType: 'api' | 'oauth2' | 'api-key';
     readonly accessToken?: string;
-    readonly username?: string;
-    readonly password?: string;
     readonly clientId?: string;
     readonly clientSecret?: string;
     readonly apiKey?: string;

--- a/packages/web/lib/api/sourceInvites.test.ts
+++ b/packages/web/lib/api/sourceInvites.test.ts
@@ -1,0 +1,96 @@
+/**
+ * SOURCE_INVITE.md §6 / §9
+ */
+
+import { sourceInvitesApi } from './sourceInvites';
+
+function fakeResponse(body: unknown, status = 200): Response {
+  const isOk = status >= 200 && status < 300;
+  return {
+    ok: isOk,
+    status,
+    json: () => Promise.resolve(body),
+    headers: new Headers(),
+    redirected: false,
+    statusText: isOk ? 'OK' : 'Error',
+    type: 'basic' as ResponseType,
+    url: '',
+    clone: function () {
+      return this as Response;
+    },
+    body: null,
+    bodyUsed: false,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    bytes: () => Promise.resolve(new Uint8Array()),
+  } as Response;
+}
+
+const BASE = 'http://localhost:2801/api';
+
+describe('sourceInvitesApi', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(fakeResponse({}));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).window = undefined;
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('issue posts only the allowlisted body', async () => {
+    const body = {
+      success: true as const,
+      expiresAt: '2026-08-22T00:00:00.000Z',
+      emailedTo: 'parent@example.com',
+    };
+    fetchSpy.mockResolvedValue(fakeResponse(body));
+    const request = {
+      studentId: 'stu-1',
+      provider: 'skyward' as const,
+      portalBaseUrl: 'https://skyward.iscorp.com',
+    };
+    const result = await sourceInvitesApi.issue(request);
+    expect(result).toEqual(body);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${BASE}/source-invites`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(request),
+      })
+    );
+    const sent = JSON.parse(String((fetchSpy.mock.calls[0] as [string, { body: string }])[1].body)) as Record<
+      string,
+      unknown
+    >;
+    expect(sent).not.toHaveProperty('to');
+    expect(sent).not.toHaveProperty('password');
+  });
+
+  it('redeem posts token only', async () => {
+    const invite = {
+      provider: 'skyward',
+      adapterId: 'com.skyward.iscorp',
+      portalBaseUrl: 'https://skyward.iscorp.com',
+      displayName: 'Skyward',
+      studentId: 'stu-1',
+      studentExternalId: 'ava-lewis',
+      institutionExternalId: 'skyward.iscorp.com',
+    };
+    fetchSpy.mockResolvedValue(fakeResponse({ success: true, invite }));
+    const token = 'ab'.repeat(32);
+    const result = await sourceInvitesApi.redeem(token);
+    expect(result).toEqual(invite);
+    const sent = JSON.parse(String((fetchSpy.mock.calls[0] as [string, { body: string }])[1].body)) as Record<
+      string,
+      unknown
+    >;
+    expect(sent).toEqual({ token });
+    expect(sent).not.toHaveProperty('password');
+  });
+});

--- a/packages/web/lib/api/sourceInvites.ts
+++ b/packages/web/lib/api/sourceInvites.ts
@@ -1,0 +1,24 @@
+/**
+ * SOURCE_INVITE.md §6 / §9
+ */
+
+import type {
+  ISourceInviteIssueRequest,
+  ISourceInviteIssueResponse,
+  ISourceInvitePayload,
+  ISourceInviteRedeemResponse,
+} from '@scholaracle/contracts';
+import { apiClient } from './client';
+
+export const sourceInvitesApi = {
+  async issue(request: ISourceInviteIssueRequest): Promise<ISourceInviteIssueResponse> {
+    return apiClient.post<ISourceInviteIssueResponse>('/source-invites', request);
+  },
+
+  async redeem(token: string): Promise<ISourceInvitePayload> {
+    const res = await apiClient.post<ISourceInviteRedeemResponse>('/source-invites/redeem', {
+      token,
+    });
+    return res.invite;
+  },
+};

--- a/packages/web/lib/api/sources.ts
+++ b/packages/web/lib/api/sources.ts
@@ -16,12 +16,10 @@ export interface IDataSource {
   readonly lastError?: string | null;
 }
 
-/** Credentials for API (token) or portal login (username/password for scraping). */
+/** API (OAuth token) credentials only. Portal username/password is never uploaded to the server. */
 export interface ISourceCredentialsRequest {
-  readonly authType: 'api' | 'login';
-  readonly accessToken?: string;
-  readonly username?: string;
-  readonly password?: string;
+  readonly authType: 'api';
+  readonly accessToken: string;
   readonly baseUrl?: string;
 }
 

--- a/packages/web/lib/install/invitePrefill.test.ts
+++ b/packages/web/lib/install/invitePrefill.test.ts
@@ -1,0 +1,26 @@
+/**
+ * SOURCE_INVITE.md §9
+ */
+
+import { SOURCE_INVITE_ADAPTER_IDS, type ISourceInvitePayload } from '@scholaracle/contracts';
+import { invitePrefillFromRedeem } from './invitePrefill';
+
+const AVA: ISourceInvitePayload = {
+  provider: 'skyward',
+  adapterId: SOURCE_INVITE_ADAPTER_IDS.skyward,
+  portalBaseUrl: 'https://skyward.iscorp.com',
+  displayName: 'Skyward Family Access (skyward.iscorp.com)',
+  studentId: 'stu-1',
+  studentExternalId: 'ava-lewis',
+  institutionExternalId: 'skyward.iscorp.com',
+};
+
+describe('invitePrefillFromRedeem', () => {
+  it('copies provider and url without password', () => {
+    const prefill = invitePrefillFromRedeem(AVA);
+    expect(prefill.provider).toBe('skyward');
+    expect(prefill.portalBaseUrl).toBe('https://skyward.iscorp.com');
+    expect(Object.keys(prefill)).not.toContain('password');
+    expect(JSON.stringify(prefill)).not.toMatch(/password/i);
+  });
+});

--- a/packages/web/lib/install/invitePrefill.ts
+++ b/packages/web/lib/install/invitePrefill.ts
@@ -1,0 +1,41 @@
+/**
+ * SOURCE_INVITE.md §9 — sessionStorage prefill after redeem (never password).
+ */
+
+import type { ISourceInvitePayload } from '@scholaracle/contracts';
+
+export const SOURCE_INVITE_PREFILL_KEY = 'slc_source_invite_prefill';
+
+export interface ISourceInvitePrefill {
+  readonly provider: string;
+  readonly portalBaseUrl: string;
+  readonly displayName: string;
+  readonly studentId: string;
+  readonly studentExternalId: string;
+}
+
+export function invitePrefillFromRedeem(invite: ISourceInvitePayload): ISourceInvitePrefill {
+  return {
+    provider: invite.provider,
+    portalBaseUrl: invite.portalBaseUrl,
+    displayName: invite.displayName,
+    studentId: invite.studentId,
+    studentExternalId: invite.studentExternalId,
+  };
+}
+
+export function storeInvitePrefill(prefill: ISourceInvitePrefill): void {
+  if (typeof sessionStorage === 'undefined') return;
+  sessionStorage.setItem(SOURCE_INVITE_PREFILL_KEY, JSON.stringify(prefill));
+}
+
+export function readInvitePrefill(): ISourceInvitePrefill | null {
+  if (typeof sessionStorage === 'undefined') return null;
+  const raw = sessionStorage.getItem(SOURCE_INVITE_PREFILL_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ISourceInvitePrefill;
+  } catch {
+    return null;
+  }
+}

--- a/packages/web/lib/install/parseInstallSearch.test.ts
+++ b/packages/web/lib/install/parseInstallSearch.test.ts
@@ -1,0 +1,20 @@
+/**
+ * SOURCE_INVITE.md §9
+ */
+
+import { parseInstallSearch } from './parseInstallSearch';
+
+const HEX = 'ab'.repeat(32);
+
+describe('parseInstallSearch', () => {
+  it('reads t from search', () => {
+    expect(parseInstallSearch(`?t=${HEX}`)).toBe(HEX);
+    expect(parseInstallSearch(`t=${HEX}`)).toBe(HEX);
+  });
+
+  it('returns null for missing or invalid t', () => {
+    expect(parseInstallSearch('')).toBeNull();
+    expect(parseInstallSearch('?foo=1')).toBeNull();
+    expect(parseInstallSearch('?t=short')).toBeNull();
+  });
+});

--- a/packages/web/lib/install/parseInstallSearch.ts
+++ b/packages/web/lib/install/parseInstallSearch.ts
@@ -1,0 +1,19 @@
+/**
+ * SOURCE_INVITE.md §9 — parse ?t= from a search string.
+ */
+
+import { sanitizeInstallToken } from '@scholaracle/contracts';
+
+export function parseInstallSearch(search: string): string | null {
+  const raw = search.startsWith('?') ? search.slice(1) : search;
+  const parts = raw.split('&');
+  for (const part of parts) {
+    const eq = part.indexOf('=');
+    const key = (eq >= 0 ? part.slice(0, eq) : part).toLowerCase();
+    if (key !== 't') continue;
+    const value = eq >= 0 ? decodeURIComponent(part.slice(eq + 1)) : '';
+    const token = sanitizeInstallToken(value);
+    return token === '' ? null : token;
+  }
+  return null;
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,6 +14,7 @@
     "test:coverage": "jest"
   },
   "dependencies": {
+    "@scholaracle/contracts": "workspace:*",
     "@hookform/resolvers": "^5.2.2",
     "@sentry/nextjs": "^10.0.0",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/workers/src/adapter-runner.ts
+++ b/packages/workers/src/adapter-runner.ts
@@ -1,80 +1,45 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 /**
  * Server-side adapter runner.
  *
- * Google Classroom and OneRoster remain server-side (OAuth/REST).
- * Canvas, Skyward, and Aeries are client-side only (mobile app / browser extension).
+ * All providers are now client-side only (mobile app / browser extension / local CLI).
+ * Canvas, Skyward, Aeries, Google Classroom, and OneRoster are synced client-side.
+ * The server no longer holds school portal or Classroom OAuth tokens for data fetching.
  */
 
-import type { ISlcIngestEnvelopeV1 } from '@scholaracle/contracts';
-import type { AdapterRunnerFn, IAdapterRunnerOptions } from '@scholaracle/agents';
+import type { AdapterRunnerFn } from '@scholaracle/agents';
 import { getErrorReporter } from '@scholaracle/contracts';
 import { logger } from './logger';
 
-/**
- * Get Google access token, refreshing if needed.
- */
-async function getGoogleAccessToken(credentials: Record<string, string>): Promise<string> {
-  let accessToken = credentials['accessToken'] ?? '';
-  const refreshToken = credentials['refreshToken'] ?? '';
-  if (refreshToken) {
-    const clientId = process.env['GOOGLE_CLASSROOM_CLIENT_ID'];
-    const clientSecret = process.env['GOOGLE_CLASSROOM_CLIENT_SECRET'];
-    if (clientId && clientSecret) {
-      const refreshed = await refreshGoogleToken(clientId, clientSecret, refreshToken);
-      if (refreshed) accessToken = refreshed;
-    }
-  }
-  return accessToken;
-}
+const CLIENT_SIDE_PROVIDERS = new Set([
+  'canvas',
+  'skyward',
+  'aeries',
+  'google-classroom',
+  'oneroster',
+]);
 
-/** Create the adapter runner (no DB / Playwright dependency). */
+/** Create the adapter runner. */
 export function createAdapterRunner(): AdapterRunnerFn {
   return async (
     provider: string,
     _adapterId: string,
-    credentials: Record<string, string>,
-    baseUrl: string,
-    runId: string,
-    options?: IAdapterRunnerOptions
+    _credentials: Record<string, string>,
+    _baseUrl: string,
+    runId: string
   ) => {
-    logger.info({ runId, provider, baseUrl, job: 'adapter-runner' }, 'adapter run started');
+    logger.info({ runId, provider, job: 'adapter-runner' }, 'adapter run started');
 
     try {
-      switch (provider) {
-        case 'canvas':
-        case 'skyward':
-        case 'aeries': {
-          logger.info(
-            { runId, provider, job: 'adapter-runner' },
-            'skipped - client-side sync only'
-          );
-          return {
-            success: false,
-            summary: {},
-            error: `${provider} sync requires the Scholaracle mobile app or browser extension. Server-side Playwright sync has been retired for this provider.`,
-          };
-        }
-
-        case 'google-classroom': {
-          const accessToken = await getGoogleAccessToken(credentials);
-          if (!accessToken) {
-            return {
-              success: false,
-              summary: {},
-              error: 'Google Classroom requires an OAuth access token',
-            };
-          }
-          return await runGoogleClassroomApi(accessToken, runId, options);
-        }
-
-        case 'oneroster': {
-          return await runOneRosterApi(baseUrl, credentials, runId, options);
-        }
-
-        default:
-          return { success: false, summary: {}, error: `Unknown provider: ${provider}` };
+      if (CLIENT_SIDE_PROVIDERS.has(provider)) {
+        logger.info({ runId, provider, job: 'adapter-runner' }, 'refused - client-side sync only');
+        return {
+          success: false,
+          summary: {},
+          error: `${provider} sync runs on the client device (mobile app, browser extension, or local CLI). Server-side sync for this provider is discontinued.`,
+        };
       }
+
+      return { success: false, summary: {}, error: `Unknown provider: ${provider}` };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       logger.error({ err, runId, provider, job: 'adapter-runner' }, 'adapter run failed');
@@ -82,105 +47,4 @@ export function createAdapterRunner(): AdapterRunnerFn {
       return { success: false, summary: {}, error: msg };
     }
   };
-}
-
-const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
-
-async function refreshGoogleToken(
-  clientId: string,
-  clientSecret: string,
-  refreshToken: string
-): Promise<string | null> {
-  try {
-    const res = await fetch(GOOGLE_TOKEN_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        client_id: clientId,
-        client_secret: clientSecret,
-        refresh_token: refreshToken,
-        grant_type: 'refresh_token',
-      }),
-    });
-    if (!res.ok) return null;
-    const data = (await res.json()) as { access_token?: string };
-    return data.access_token ?? null;
-  } catch (err) {
-    logger.warn({ err, job: 'adapter-runner' }, 'google token refresh failed');
-    return null;
-  }
-}
-
-async function runGoogleClassroomApi(
-  token: string,
-  runId: string,
-  options?: IAdapterRunnerOptions
-): Promise<{
-  success: boolean;
-  summary: Record<string, number>;
-  error?: string;
-  envelope?: ISlcIngestEnvelopeV1;
-}> {
-  try {
-    const { GoogleClassroomAdapter } = await import('@scholaracle/connector');
-    const adapter = new GoogleClassroomAdapter();
-    await adapter.authenticate({
-      baseUrl: 'https://classroom.googleapis.com',
-      accessToken: token,
-    });
-
-    const sourceId = options?.sourceId ?? runId;
-    const displayName = options?.displayName ?? 'Google Classroom';
-    const envelope = await adapter.fetchEnvelope({ runId, sourceId, displayName });
-
-    const courses = envelope.ops.filter((o: { entity: string }) => o.entity === 'course').length;
-    const assignments = envelope.ops.filter(
-      (o: { entity: string }) => o.entity === 'assignment'
-    ).length;
-
-    return { success: true, summary: { courses, assignments }, envelope };
-  } catch (err) {
-    return { success: false, summary: {}, error: (err as Error).message };
-  }
-}
-
-async function runOneRosterApi(
-  baseUrl: string,
-  credentials: Record<string, string>,
-  runId: string,
-  options?: IAdapterRunnerOptions
-): Promise<{
-  success: boolean;
-  summary: Record<string, number>;
-  error?: string;
-  envelope?: ISlcIngestEnvelopeV1;
-}> {
-  try {
-    const { OneRosterAdapter } = await import('@scholaracle/connector');
-    const adapter = new OneRosterAdapter();
-    await adapter.authenticate({
-      baseUrl,
-      clientId: credentials['clientId'],
-      clientSecret: credentials['clientSecret'],
-      accessToken: credentials['accessToken'],
-    });
-
-    const sourceId = options?.sourceId ?? runId;
-    const displayName = options?.displayName ?? 'OneRoster';
-    const envelope = await adapter.fetchEnvelope({
-      runId,
-      sourceId,
-      displayName,
-      portalBaseUrl: baseUrl,
-    });
-
-    const courses = envelope.ops.filter((o: { entity: string }) => o.entity === 'course').length;
-    const assignments = envelope.ops.filter(
-      (o: { entity: string }) => o.entity === 'assignment'
-    ).length;
-
-    return { success: true, summary: { courses, assignments }, envelope };
-  } catch (err) {
-    return { success: false, summary: {}, error: (err as Error).message };
-  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@scholaracle/logger':
         specifier: workspace:*
         version: link:../logger
+      '@scholaracle/scraper-core':
+        specifier: workspace:*
+        version: link:../scraper-core
       '@sendgrid/mail':
         specifier: ^8.1.0
         version: 8.1.6
@@ -535,10 +538,10 @@ importers:
         version: 1.20.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+        version: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3))
       ts-jest:
         specifier: ^29.1.1
-        version: 29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)))(typescript@6.0.3)
+        version: 29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3)))(typescript@6.0.3)
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -616,6 +619,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@scholaracle/contracts':
+        specifier: workspace:*
+        version: link:../contracts
       '@sentry/nextjs':
         specifier: ^10.0.0
         version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.0.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(webpack@5.109.2)
@@ -10401,7 +10407,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -10415,7 +10421,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -13197,13 +13203,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
+  create-jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -15069,16 +15075,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
+  jest-cli@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      create-jest: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.3
@@ -15119,7 +15125,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
+  jest-config@29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/test-sequencer': 29.7.0
@@ -15145,7 +15151,38 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.43
-      ts-node: 10.9.2(@types/node@20.19.43)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@22.20.1)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.20.1
+      ts-node: 10.9.2(@types/node@22.20.1)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -15423,12 +15460,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)):
+  jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      jest-cli: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -17659,12 +17696,12 @@ snapshots:
       esbuild: 0.24.2
       jest-util: 30.4.1
 
-  ts-jest@29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3)))(typescript@6.0.3):
+  ts-jest@29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -17715,14 +17752,14 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@20.19.43)(typescript@6.0.3):
+  ts-node@10.9.2(@types/node@22.20.1)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.43
+      '@types/node': 22.20.1
       acorn: 8.18.0
       acorn-walk: 8.3.5
       arg: 4.1.3


### PR DESCRIPTION
## Summary
- Move portal extraction onto the client (`runClientScrape` in scraper-core) so the server no longer stores or fetches school passwords.
- Add fail-open join-gap enrichment on ingest, default off (`ENRICH_OPS_MODE`).
- Email a no-secrets source invite: HTTPS landing → iOS/Android app or Continue in browser; portal password is typed on-device.

## Test plan
- [ ] API: issue/redeem source invite, landing HTML has no portal URL/password
- [ ] Dashboard: Email me an install link for Skyward `https://skyward.iscorp.com`
- [ ] Mobile: tap `scholarmancy://install-source?t=…` registers source without writing Keychain until credentials
- [ ] Web: Continue in browser redeems and drops `t` from the URL
- [ ] Sync still works for Canvas/Skyward/Aeries builtins (`com.skyward.iscorp` alias)


Made with [Cursor](https://cursor.com)