### PR TITLE
Build contracts before Next in web Docker image

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -36,6 +36,8 @@ COPY . .
 ARG NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 
+# Web imports compiled contracts (`main: dist/index.js`); Next cannot resolve the TS source.
+RUN pnpm --filter @scholaracle/contracts build
 RUN pnpm --filter @scholaracle/web build
 RUN date -u +%Y-%m-%dT%H:%M:%SZ > /app/BUILT_AT
 


### PR DESCRIPTION
## Summary
- `#8` added a `@scholaracle/contracts` import to the web app, but `Dockerfile.web` only ran `next build`.
- Compile contracts first so the image can resolve `dist/index.js`.

## Test plan
- [ ] CI Docker build (pre-deploy) web image succeeds


Made with [Cursor](https://cursor.com)