### PR TITLE
Add in-app first-run wizard so parents can download and set up kids

### DIFF
--- a/packages/contracts/src/types/api/students.ts
+++ b/packages/contracts/src/types/api/students.ts
@@ -26,3 +26,10 @@ export interface IStudentListItem {
   readonly studentId?: string;
   readonly stats?: IStudentStatsWire;
 }
+
+/** Request body of POST /api/students. */
+export interface IStudentCreateRequest {
+  readonly name: string;
+  readonly grade?: number;
+  readonly studentId?: string;
+}

--- a/packages/mobile/App.tsx
+++ b/packages/mobile/App.tsx
@@ -8,8 +8,9 @@ import { View, StyleSheet, Alert } from 'react-native';
 import { useLinkingURL } from 'expo-linking';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { AuthProvider, useAuth } from './src/auth/AuthContext';
-import { LoginScreen } from './src/screens/LoginScreen';
 import { StudentsScreen } from './src/screens/StudentsScreen';
+import { OnboardingScreen } from './src/onboarding/OnboardingScreen';
+import type { IApplyOnboardingResult } from './src/onboarding/applyOnboarding';
 import { ConnectSourceScreen } from './src/screens/ConnectSourceScreen';
 import { DashboardScreen } from './src/screens/DashboardScreen';
 import { CourseDetailScreen } from './src/screens/CourseDetailScreen';
@@ -62,6 +63,7 @@ interface INavState {
 function AppContent(): React.ReactElement {
   const { isLoggedIn, isLoading, login, accountEpoch } = useAuth();
   const [nav, setNav] = useState<INavState>({ view: 'students' });
+  const [studentCount, setStudentCount] = useState<number | null>(null);
   const linkingUrl = useLinkingURL();
   const handledDemoUrl = useRef<string | null>(null);
   const handledDiagUrl = useRef<string | null>(null);
@@ -134,11 +136,22 @@ function AppContent(): React.ReactElement {
   }, [isLoading, isLoggedIn, applyInviteNav]);
 
   useEffect(() => {
-    if (isLoggedIn) {
+    if (!isLoggedIn) {
+      setStudentCount(null);
+      return;
+    }
+    void apiClient
+      .getStudents()
+      .then((rows) => setStudentCount(rows.length))
+      .catch(() => setStudentCount(0));
+  }, [isLoggedIn, accountEpoch]);
+
+  useEffect(() => {
+    if (isLoggedIn && studentCount != null && studentCount > 0) {
       void registerForPushNotifications();
       void seedSecureStoreFromDevEnv();
     }
-  }, [isLoggedIn]);
+  }, [isLoggedIn, studentCount]);
 
   // Notification taps open the app at the students list (data refetches on
   // mount, so the fresh alert context is visible immediately).
@@ -155,10 +168,7 @@ function AppContent(): React.ReactElement {
   }, [isLoggedIn]);
 
   const startSync = useCallback(async (student: IStudentListItem) => {
-    // Sources are keyed by the external (SIS/portal) student id.
-    const source = student.studentId
-      ? await connectedSourceStore.getForStudent(student.studentId)
-      : null;
+    const source = await connectedSourceStore.getForStudentRecord(student);
     if (!source) {
       Alert.alert(
         'No portal connected',
@@ -170,8 +180,22 @@ function AppContent(): React.ReactElement {
     setNav({ view: 'sync', student, syncSource: source });
   }, []);
 
+  const finishOnboarding = useCallback(async (result: IApplyOnboardingResult) => {
+    setStudentCount(result.students.length);
+    const first = result.students[0];
+    if (!first) {
+      setNav({ view: 'students' });
+      return;
+    }
+    const source = await connectedSourceStore.getForStudentRecord(first);
+    if (source) {
+      setNav({ view: 'sync', student: first, syncSource: source });
+      return;
+    }
+    setNav({ view: 'dashboard', student: first });
+  }, []);
+
   if (isLoading) return <View style={styles.loading} />;
-  if (!isLoggedIn) return <LoginScreen />;
 
   if (nav.view === 'connect-source') {
     return (
@@ -185,6 +209,32 @@ function AppContent(): React.ReactElement {
         onCancel={() =>
           setNav({ view: nav.student ? 'dashboard' : 'students', student: nav.student })
         }
+      />
+    );
+  }
+
+  if (!isLoggedIn) {
+    return (
+      <OnboardingScreen
+        entry="logged-out"
+        onComplete={(result) => {
+          void finishOnboarding(result);
+        }}
+      />
+    );
+  }
+
+  if (studentCount === null) {
+    return <View style={styles.loading} />;
+  }
+
+  if (studentCount === 0 && nav.view === 'students') {
+    return (
+      <OnboardingScreen
+        entry="logged-in"
+        onComplete={(result) => {
+          void finishOnboarding(result);
+        }}
       />
     );
   }
@@ -269,6 +319,7 @@ function AppContent(): React.ReactElement {
       key={accountEpoch}
       onSelectStudent={(student) => setNav({ view: 'dashboard', student })}
       onAddSource={() => setNav({ view: 'connect-source' })}
+      onStartSetup={() => setNav({ view: 'students' })}
       onOpenSettings={() => setNav({ view: 'settings' })}
     />
   );

--- a/packages/mobile/src/api/client.test.ts
+++ b/packages/mobile/src/api/client.test.ts
@@ -107,6 +107,57 @@ describe('ScholarmancyApiClient auth', () => {
     });
   });
 
+  describe('register', () => {
+    it('should POST /api/auth/register and store tokens from the `token` field', async () => {
+      const fetchMock = mockFetchSequence({ status: 201, body: makeLoginBody() });
+
+      await client.register('parent@example.com', 'password12', 'Ricardo');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE_URL}/api/auth/register`,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            email: 'parent@example.com',
+            password: 'mock-password12',
+            name: 'Ricardo',
+            rememberMe: true,
+          }),
+        })
+      );
+      expect(secureStoreData.get('slc_access_token')).toBe('jwt-access-token-1');
+      expect(secureStoreData.get('slc_refresh_token')).toBe('refresh-token-1');
+    });
+
+    it('should throw when register returns no token', async () => {
+      mockFetchSequence({ status: 201, body: { success: false } });
+      await expect(client.register('a@b.c', 'password12', 'A')).rejects.toThrow(/token/i);
+    });
+  });
+
+  describe('createStudent', () => {
+    it('should POST /api/students and return the created row', async () => {
+      secureStoreData.set('slc_access_token', 'jwt-ok');
+      const created = {
+        id: 'stu-mongo-1',
+        userId: 'user-1',
+        name: 'Gideon',
+        grade: 8,
+      };
+      const fetchMock = mockFetchSequence({ status: 201, body: created });
+
+      await expect(client.createStudent({ name: 'Gideon', grade: 8 })).resolves.toEqual(created);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE_URL}/api/students`,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ name: 'Gideon', grade: 8 }),
+          headers: expect.objectContaining({ Authorization: 'Bearer jwt-ok' }),
+        })
+      );
+    });
+  });
+
   describe('token refresh', () => {
     it('should refresh using the `token` field and store the rotated refresh token', async () => {
       // No access token stored; only a refresh token.

--- a/packages/mobile/src/api/client.ts
+++ b/packages/mobile/src/api/client.ts
@@ -14,6 +14,7 @@ import { Platform } from 'react-native';
 import type {
   ISlcIngestEnvelopeV1,
   IStudentListItem,
+  IStudentCreateRequest,
   IStudentGradesResponse,
   IStudentMaterialsResponse,
   IActionBoardResponse,
@@ -96,15 +97,22 @@ export class ScholarmancyApiClient {
 
   async login(email: string, password: string): Promise<IAuthLoginResponse> {
     const res = await this._post<IAuthLoginResponse>('/api/auth/login', { email, password }, false);
-    if (!res.token) {
-      throw new Error('Login response did not include an access token');
-    }
-    await SecureStore.setItemAsync(ACCESS_TOKEN_KEY, res.token);
-    if (res.refreshToken) {
-      await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, res.refreshToken);
-    }
-    this._sessionEpoch += 1;
+    await this._persistSession(res, 'Login');
     return res;
+  }
+
+  async register(email: string, password: string, name: string): Promise<IAuthLoginResponse> {
+    const res = await this._post<IAuthLoginResponse>(
+      '/api/auth/register',
+      { email, password, name, rememberMe: true },
+      false
+    );
+    await this._persistSession(res, 'Register');
+    return res;
+  }
+
+  async createStudent(request: IStudentCreateRequest): Promise<IStudentListItem> {
+    return this._post<IStudentListItem>('/api/students', request, true);
   }
 
   async logout(): Promise<void> {
@@ -401,6 +409,17 @@ export class ScholarmancyApiClient {
   // ---------------------------------------------------------------------------
   // Internal helpers
   // ---------------------------------------------------------------------------
+
+  private async _persistSession(res: IAuthLoginResponse, action: string): Promise<void> {
+    if (!res.token) {
+      throw new Error(`${action} response did not include an access token`);
+    }
+    await SecureStore.setItemAsync(ACCESS_TOKEN_KEY, res.token);
+    if (res.refreshToken) {
+      await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, res.refreshToken);
+    }
+    this._sessionEpoch += 1;
+  }
 
   private async _getAccessToken(): Promise<string> {
     const token = await SecureStore.getItemAsync(ACCESS_TOKEN_KEY);

--- a/packages/mobile/src/api/interfaces.ts
+++ b/packages/mobile/src/api/interfaces.ts
@@ -6,6 +6,7 @@
 import type {
   ISlcIngestEnvelopeV1,
   IStudentListItem,
+  IStudentCreateRequest,
   IStudentGradesResponse,
   IAuthLoginResponse,
   ISourceInviteIssueRequest,
@@ -15,6 +16,7 @@ import type {
 
 export interface IAuthSession {
   login(email: string, password: string): Promise<IAuthLoginResponse>;
+  register(email: string, password: string, name: string): Promise<IAuthLoginResponse>;
   logout(): Promise<void>;
   isLoggedIn(): Promise<boolean>;
 }
@@ -25,6 +27,7 @@ export interface IConnectorTokenProvider {
 
 export interface IStudentReadApi {
   getStudents(): Promise<IStudentListItem[]>;
+  createStudent(request: IStudentCreateRequest): Promise<IStudentListItem>;
   getStudentAssignments(studentId: string): Promise<readonly unknown[]>;
   getStudentGrades(studentId: string): Promise<IStudentGradesResponse>;
   getStudentRuns(studentId: string): Promise<readonly unknown[]>;

--- a/packages/mobile/src/auth/AuthContext.tsx
+++ b/packages/mobile/src/auth/AuthContext.tsx
@@ -24,6 +24,7 @@ interface IAuthState {
 
 interface IAuthActions {
   login(email: string, password: string): Promise<void>;
+  register(email: string, password: string, name: string): Promise<void>;
   logout(): Promise<void>;
 }
 
@@ -72,6 +73,24 @@ export function AuthProvider({
     };
   }, []);
 
+  const register = useCallback(async (email: string, password: string, name: string) => {
+    setState((s) => ({ ...s, isAuthenticating: true, error: null }));
+    try {
+      await apiClient.register(email, password, name);
+      setState((s) => ({
+        ...s,
+        isLoggedIn: true,
+        isAuthenticating: false,
+        error: null,
+        accountEpoch: s.accountEpoch + 1,
+      }));
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Registration failed';
+      setState((s) => ({ ...s, isAuthenticating: false, error: msg }));
+      throw err;
+    }
+  }, []);
+
   const login = useCallback(async (email: string, password: string) => {
     setState((s) => ({ ...s, isAuthenticating: true, error: null }));
     try {
@@ -100,7 +119,9 @@ export function AuthProvider({
   }, []);
 
   return (
-    <AuthContext.Provider value={{ ...state, login, logout }}>{children}</AuthContext.Provider>
+    <AuthContext.Provider value={{ ...state, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
   );
 }
 

--- a/packages/mobile/src/onboarding/OnboardingScreen.tsx
+++ b/packages/mobile/src/onboarding/OnboardingScreen.tsx
@@ -1,0 +1,424 @@
+/**
+ * First-run wizard: account → children → school system → portal URL →
+ * school password (Keychain only). Completing creates the household on
+ * the server and local connected sources.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useAuth } from '../auth/AuthContext';
+import { apiClient } from '../api/client';
+import { saveLogin } from '../credentials/savedLoginStore';
+import { connectedSourceStore } from '../sources/ConnectedSourceStore';
+import { applyOnboarding, type IApplyOnboardingResult } from './applyOnboarding';
+import {
+  addChild,
+  canAdvance,
+  createInitialOnboardingState,
+  reduceOnboarding,
+  removeChild,
+  updateChild,
+  type OnboardingEntry,
+  type OnboardingProvider,
+} from './onboardingMachine';
+import { registerForPushNotifications } from '../notifications/pushSetup';
+
+const PROVIDERS: readonly { id: OnboardingProvider; name: string; urlHint: string }[] = [
+  { id: 'skyward', name: 'Skyward Family Access', urlHint: 'https://skyward.iscorp.com' },
+  { id: 'canvas', name: 'Canvas LMS', urlHint: 'https://yourschool.instructure.com' },
+  { id: 'aeries', name: 'Aeries Parent Portal', urlHint: 'https://yourschool.aeries.net' },
+];
+
+export interface IOnboardingScreenProps {
+  readonly entry: OnboardingEntry;
+  onComplete(result: IApplyOnboardingResult): void;
+}
+
+export function OnboardingScreen({
+  entry,
+  onComplete,
+}: IOnboardingScreenProps): React.ReactElement {
+  const { login, register, isAuthenticating, error } = useAuth();
+  const [state, setState] = useState(() => createInitialOnboardingState(entry));
+  const [busy, setBusy] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [alertsDone, setAlertsDone] = useState(false);
+  const [applyResult, setApplyResult] = useState<IApplyOnboardingResult | null>(null);
+
+  const ready = useMemo(() => canAdvance(state), [state]);
+
+  const submitAccount = async (): Promise<void> => {
+    const email = state.email.trim();
+    if (state.accountMode === 'create') {
+      await register(email, state.password, state.parentName.trim());
+    } else {
+      await login(email, state.password);
+    }
+    await saveLogin({ email, password: state.password }).catch(() => undefined);
+  };
+
+  const handleNext = async (): Promise<void> => {
+    setLocalError(null);
+    if (state.step === 'account') {
+      if (!ready || isAuthenticating) return;
+      setBusy(true);
+      try {
+        await submitAccount();
+        // App remounts at children once isLoggedIn; do not advance locally.
+      } catch {
+        // AuthContext owns the message.
+      } finally {
+        setBusy(false);
+      }
+      return;
+    }
+    if (state.step !== 'credentials') {
+      if (!ready) return;
+      setState((s) => reduceOnboarding(s, { type: 'next' }));
+      return;
+    }
+    if (!ready || busy) return;
+    setBusy(true);
+    try {
+      const result = await applyOnboarding(state, {
+        createStudent: (req) => apiClient.createStudent(req),
+        registerIngestSource: (src) => apiClient.registerIngestSource(src),
+        sources: connectedSourceStore,
+      });
+      setApplyResult(result);
+    } catch (err: unknown) {
+      setLocalError(err instanceof Error ? err.message : 'Could not finish setup');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const finishAlerts = (enable: boolean): void => {
+    if (enable) {
+      void registerForPushNotifications();
+    }
+    if (applyResult) onComplete(applyResult);
+  };
+
+  if (applyResult && !alertsDone) {
+    return (
+      <View style={styles.body}>
+        <Text style={styles.stepTitle}>Stay in the loop</Text>
+        <Text style={styles.help}>
+          After the first sync, Scholarmancy can notify you about missing work and grade drops. You
+          can change this later in Settings.
+        </Text>
+        {applyResult.planLimitReached && (
+          <Text style={styles.warn}>
+            Your plan allows one student on this account.{' '}
+            {applyResult.students[0]?.name ?? 'The first child'} is set up — upgrade later to add
+            another.
+          </Text>
+        )}
+        <TouchableOpacity
+          style={styles.button}
+          onPress={() => {
+            setAlertsDone(true);
+            finishAlerts(true);
+          }}
+          testID="button-enable-alerts"
+        >
+          <Text style={styles.buttonText}>Enable alerts</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.secondaryButton}
+          onPress={() => {
+            setAlertsDone(true);
+            finishAlerts(false);
+          }}
+          testID="button-skip-alerts"
+        >
+          <Text style={styles.secondaryButtonText}>Not now</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <ScrollView contentContainerStyle={styles.body} keyboardShouldPersistTaps="handled">
+        {state.step !== 'account' && (
+          <TouchableOpacity onPress={() => setState((s) => reduceOnboarding(s, { type: 'back' }))}>
+            <Text style={styles.back}>Back</Text>
+          </TouchableOpacity>
+        )}
+
+        {state.step === 'account' && (
+          <>
+            <Text style={styles.title}>Scholarmancy</Text>
+            <Text style={styles.subtitle}>
+              {state.accountMode === 'create'
+                ? 'Create your parent account'
+                : 'Sign in to your account'}
+            </Text>
+            {state.accountMode === 'create' && (
+              <TextInput
+                style={styles.input}
+                placeholder="Your name"
+                placeholderTextColor="#999"
+                value={state.parentName}
+                onChangeText={(value) =>
+                  setState((s) => reduceOnboarding(s, { type: 'set-parent-name', value }))
+                }
+                testID="input-parent-name"
+              />
+            )}
+            <TextInput
+              style={styles.input}
+              placeholder="Email"
+              placeholderTextColor="#999"
+              autoCapitalize="none"
+              keyboardType="email-address"
+              value={state.email}
+              onChangeText={(value) =>
+                setState((s) => reduceOnboarding(s, { type: 'set-email', value }))
+              }
+              testID="input-email"
+            />
+            <TextInput
+              style={styles.input}
+              placeholder={state.accountMode === 'create' ? 'Password (8+ characters)' : 'Password'}
+              placeholderTextColor="#999"
+              secureTextEntry
+              value={state.password}
+              onChangeText={(value) =>
+                setState((s) => reduceOnboarding(s, { type: 'set-password', value }))
+              }
+              testID="input-password"
+            />
+            <TouchableOpacity
+              onPress={() =>
+                setState((s) =>
+                  reduceOnboarding(s, {
+                    type: 'set-account-mode',
+                    mode: s.accountMode === 'create' ? 'signin' : 'create',
+                  })
+                )
+              }
+            >
+              <Text style={styles.link}>
+                {state.accountMode === 'create'
+                  ? 'I already have an account'
+                  : 'Create a new account'}
+              </Text>
+            </TouchableOpacity>
+          </>
+        )}
+
+        {state.step === 'children' && (
+          <>
+            <Text style={styles.stepTitle}>Who are we tracking?</Text>
+            <Text style={styles.help}>
+              Add each child. You can share one school login for both.
+            </Text>
+            {state.children.map((child, index) => (
+              <View key={child.key} style={styles.childRow}>
+                <TextInput
+                  style={[styles.input, styles.childName]}
+                  placeholder={index === 0 ? 'First name (e.g. Gideon)' : 'First name'}
+                  placeholderTextColor="#999"
+                  value={child.name}
+                  onChangeText={(name) => setState((s) => updateChild(s, child.key, { name }))}
+                  testID={`input-child-name-${index}`}
+                />
+                <TextInput
+                  style={[styles.input, styles.childGrade]}
+                  placeholder="Grade"
+                  placeholderTextColor="#999"
+                  keyboardType="number-pad"
+                  value={child.grade}
+                  onChangeText={(grade) => setState((s) => updateChild(s, child.key, { grade }))}
+                />
+                {state.children.length > 1 && (
+                  <TouchableOpacity onPress={() => setState((s) => removeChild(s, child.key))}>
+                    <Text style={styles.remove}>Remove</Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+            ))}
+            <TouchableOpacity
+              onPress={() => setState((s) => addChild(s))}
+              testID="button-add-child"
+            >
+              <Text style={styles.link}>Add another child</Text>
+            </TouchableOpacity>
+          </>
+        )}
+
+        {state.step === 'provider' && (
+          <>
+            <Text style={styles.stepTitle}>School system</Text>
+            {PROVIDERS.map((p) => (
+              <TouchableOpacity
+                key={p.id}
+                style={[styles.card, state.provider === p.id && styles.cardSelected]}
+                onPress={() =>
+                  setState((s) =>
+                    reduceOnboarding(
+                      reduceOnboarding(s, { type: 'set-provider', provider: p.id }),
+                      { type: 'set-portal-url', value: p.urlHint }
+                    )
+                  )
+                }
+                testID={`button-provider-${p.id}`}
+              >
+                <Text style={styles.cardTitle}>{p.name}</Text>
+              </TouchableOpacity>
+            ))}
+          </>
+        )}
+
+        {state.step === 'portal-url' && (
+          <>
+            <Text style={styles.stepTitle}>Portal address</Text>
+            <Text style={styles.help}>The site you open to check grades in a browser.</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="https://…"
+              placeholderTextColor="#999"
+              autoCapitalize="none"
+              autoCorrect={false}
+              value={state.portalUrl}
+              onChangeText={(value) =>
+                setState((s) => reduceOnboarding(s, { type: 'set-portal-url', value }))
+              }
+              testID="input-portal-url"
+            />
+          </>
+        )}
+
+        {state.step === 'credentials' && (
+          <>
+            <Text style={styles.stepTitle}>School sign-in</Text>
+            <Text style={styles.help}>
+              Stored only on this phone. Scholarmancy never sends your school password to our
+              servers.
+            </Text>
+            <TextInput
+              style={styles.input}
+              placeholder="Username"
+              placeholderTextColor="#999"
+              autoCapitalize="none"
+              value={state.username}
+              onChangeText={(value) =>
+                setState((s) => reduceOnboarding(s, { type: 'set-username', value }))
+              }
+              testID="input-portal-username"
+            />
+            <TextInput
+              style={styles.input}
+              placeholder="Password"
+              placeholderTextColor="#999"
+              secureTextEntry
+              value={state.portalPassword}
+              onChangeText={(value) =>
+                setState((s) => reduceOnboarding(s, { type: 'set-portal-password', value }))
+              }
+              testID="input-portal-password"
+            />
+          </>
+        )}
+
+        {(error || localError) && (
+          <Text style={styles.error} testID="text-onboarding-error">
+            {localError ?? error}
+          </Text>
+        )}
+
+        <TouchableOpacity
+          style={[styles.button, (!ready || busy || isAuthenticating) && styles.buttonDisabled]}
+          onPress={() => void handleNext()}
+          disabled={!ready || busy || isAuthenticating}
+          testID="button-onboarding-next"
+        >
+          {busy || isAuthenticating ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.buttonText}>
+              {state.step === 'credentials' ? 'Save and continue' : 'Continue'}
+            </Text>
+          )}
+        </TouchableOpacity>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f8f9fa' },
+  body: { flexGrow: 1, justifyContent: 'center', padding: 24 },
+  title: {
+    fontSize: 32,
+    fontWeight: '700',
+    color: '#1a1a2e',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#6c757d',
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+  stepTitle: { fontSize: 22, fontWeight: '700', color: '#1a1a2e', marginBottom: 8 },
+  help: { fontSize: 15, color: '#6c757d', marginBottom: 20, lineHeight: 22 },
+  back: { color: '#4361ee', fontWeight: '600', marginBottom: 16 },
+  input: {
+    height: 52,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#dee2e6',
+    paddingHorizontal: 16,
+    fontSize: 16,
+    marginBottom: 12,
+    color: '#212529',
+  },
+  childRow: { marginBottom: 8 },
+  childName: { marginBottom: 8 },
+  childGrade: { width: 120 },
+  remove: { color: '#dc3545', fontWeight: '600', marginBottom: 12 },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#dee2e6',
+    padding: 16,
+    marginBottom: 12,
+  },
+  cardSelected: { borderColor: '#4361ee', borderWidth: 2 },
+  cardTitle: { fontSize: 16, fontWeight: '600', color: '#1a1a2e' },
+  link: { color: '#4361ee', fontWeight: '600', marginBottom: 20, textAlign: 'center' },
+  error: { color: '#dc3545', marginBottom: 12, textAlign: 'center' },
+  warn: { color: '#b45309', marginBottom: 16, lineHeight: 22 },
+  button: {
+    backgroundColor: '#4361ee',
+    height: 52,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 8,
+  },
+  buttonDisabled: { opacity: 0.5 },
+  buttonText: { color: '#fff', fontWeight: '700', fontSize: 16 },
+  secondaryButton: { height: 52, alignItems: 'center', justifyContent: 'center', marginTop: 8 },
+  secondaryButtonText: { color: '#4361ee', fontWeight: '600', fontSize: 16 },
+});

--- a/packages/mobile/src/onboarding/applyOnboarding.test.ts
+++ b/packages/mobile/src/onboarding/applyOnboarding.test.ts
@@ -1,0 +1,101 @@
+import * as SecureStore from 'expo-secure-store';
+import { ConnectedSourceStore } from '../sources/ConnectedSourceStore';
+import type { IStudentListItem } from '@scholaracle/contracts';
+import { ApiError } from '../api/ApiError';
+import { applyOnboarding } from './applyOnboarding';
+import type { IOnboardingState } from './onboardingMachine';
+import { createInitialOnboardingState, updateChild } from './onboardingMachine';
+
+function householdState(): IOnboardingState {
+  let state = createInitialOnboardingState('logged-in');
+  state = updateChild(state, state.children[0]!.key, { name: 'Gideon', grade: '8' });
+  state = {
+    ...state,
+    children: [...state.children, { key: 'c2', name: 'Christian', grade: '6' }],
+    provider: 'skyward',
+    portalUrl: 'https://skyward.iscorp.com',
+    username: 'parent',
+    portalPassword: 'mock-school-secret',
+  };
+  return state;
+}
+
+describe('applyOnboarding', () => {
+  beforeEach(async () => {
+    const AsyncStorage = (await import('@react-native-async-storage/async-storage')).default;
+    await AsyncStorage.clear();
+    (SecureStore.setItemAsync as jest.Mock).mockClear();
+  });
+
+  it('creates each named child, shares one Keychain entry, and unique source ids', async () => {
+    const created: IStudentListItem[] = [
+      { id: 'mongo-g', userId: 'u1', name: 'Gideon', grade: 8 },
+      { id: 'mongo-c', userId: 'u1', name: 'Christian', grade: 6 },
+    ];
+    let i = 0;
+    const createStudent = jest.fn(async () => created[i++]!);
+    const registerIngestSource = jest.fn(async () => undefined);
+    const store = new ConnectedSourceStore();
+
+    const result = await applyOnboarding(householdState(), {
+      createStudent,
+      registerIngestSource,
+      sources: store,
+    });
+
+    expect(createStudent).toHaveBeenCalledTimes(2);
+    expect(createStudent).toHaveBeenNthCalledWith(1, { name: 'Gideon', grade: 8 });
+    expect(createStudent).toHaveBeenNthCalledWith(2, { name: 'Christian', grade: 6 });
+    expect(result.students.map((s) => s.name)).toEqual(['Gideon', 'Christian']);
+
+    const sources = await store.list();
+    expect(sources).toHaveLength(2);
+    expect(new Set(sources.map((s) => s.sourceId)).size).toBe(2);
+    expect(sources.every((s) => s.credentialKey === sources[0]?.credentialKey)).toBe(true);
+    expect(sources.some((s) => s.studentExternalId === 'default')).toBe(false);
+    expect(sources.map((s) => s.studentId).sort()).toEqual(['mongo-c', 'mongo-g']);
+
+    expect(SecureStore.setItemAsync).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(
+      (SecureStore.setItemAsync as jest.Mock).mock.calls[0][1] as string
+    ) as {
+      username: string;
+      password: string;
+    };
+    expect(payload.username).toBe('parent');
+    expect(payload.password).toBe('mock-school-secret');
+    expect(registerIngestSource).toHaveBeenCalledTimes(2);
+  });
+
+  it('never writes studentExternalId default when SIS id is missing', async () => {
+    const store = new ConnectedSourceStore();
+    await applyOnboarding(householdState(), {
+      createStudent: async () => ({ id: 'mongo-g', userId: 'u1', name: 'Gideon' }),
+      registerIngestSource: async () => undefined,
+      sources: store,
+    });
+    const sources = await store.list();
+    expect(sources[0]?.studentExternalId).toBe('mongo-g');
+  });
+
+  it('keeps the first child when a later create hits a plan limit', async () => {
+    const store = new ConnectedSourceStore();
+    const createStudent = jest
+      .fn()
+      .mockResolvedValueOnce({ id: 'mongo-g', userId: 'u1', name: 'Gideon', grade: 8 })
+      .mockRejectedValueOnce(
+        new ApiError('Your free plan allows up to 1 student', 403, 'PLAN_LIMIT_REACHED')
+      );
+
+    const result = await applyOnboarding(householdState(), {
+      createStudent,
+      registerIngestSource: async () => undefined,
+      sources: store,
+    });
+
+    expect(result.students).toHaveLength(1);
+    expect(result.students[0]?.name).toBe('Gideon');
+    expect(result.planLimitReached).toBe(true);
+    expect(await store.list()).toHaveLength(1);
+  });
+});

--- a/packages/mobile/src/onboarding/applyOnboarding.ts
+++ b/packages/mobile/src/onboarding/applyOnboarding.ts
@@ -1,0 +1,139 @@
+/**
+ * Persist the first-run household: students on the server, one Keychain
+ * credential, and one connected source per child. Portal passwords never
+ * leave the device.
+ */
+
+import * as SecureStore from 'expo-secure-store';
+import type {
+  IIngestSourceRegisterRequest,
+  IStudentCreateRequest,
+  IStudentListItem,
+} from '@scholaracle/contracts';
+import { ApiError } from '../api/ApiError';
+import {
+  ADAPTER_IDS,
+  buildCredentialKey,
+  sourceIdForStudent,
+  type IConnectedSourceStore,
+} from '../sources/ConnectedSourceStore';
+import { extractHostname } from '../utils/urlNormalize';
+import {
+  namedChildDrafts,
+  type IOnboardingState,
+  type OnboardingProvider,
+} from './onboardingMachine';
+
+export interface IOnboardingStudentWriter {
+  createStudent(request: IStudentCreateRequest): Promise<IStudentListItem>;
+}
+
+export interface IOnboardingSourceRegistrar {
+  registerIngestSource(source: IIngestSourceRegisterRequest): Promise<void>;
+}
+
+export interface IApplyOnboardingDeps {
+  readonly createStudent: IOnboardingStudentWriter['createStudent'];
+  readonly registerIngestSource: IOnboardingSourceRegistrar['registerIngestSource'];
+  readonly sources: IConnectedSourceStore;
+}
+
+export interface IApplyOnboardingResult {
+  readonly students: readonly IStudentListItem[];
+  readonly planLimitReached: boolean;
+}
+
+function parseGrade(raw: string): number | undefined {
+  const n = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function isPlanLimit(err: unknown): boolean {
+  return err instanceof ApiError && err.code === 'PLAN_LIMIT_REACHED';
+}
+
+export async function applyOnboarding(
+  state: IOnboardingState,
+  deps: IApplyOnboardingDeps
+): Promise<IApplyOnboardingResult> {
+  const provider = state.provider;
+  if (!provider) {
+    throw new Error('Select a school system before saving');
+  }
+  const portalUrl = state.portalUrl.trim();
+  const institutionExternalId = extractHostname(portalUrl);
+  if (institutionExternalId === '') {
+    throw new Error('Enter a full portal address like https://school.example.com');
+  }
+
+  const credentialKey = buildCredentialKey(provider, portalUrl);
+  await SecureStore.setItemAsync(
+    credentialKey,
+    JSON.stringify({
+      username: state.username.trim(),
+      password: state.portalPassword,
+      baseUrl: portalUrl,
+      provider,
+      loginMethod: 'direct',
+    }),
+    { keychainAccessible: SecureStore.WHEN_UNLOCKED }
+  );
+
+  const adapterId = ADAPTER_IDS[provider] ?? `com.${provider}`;
+  const students: IStudentListItem[] = [];
+  let planLimitReached = false;
+
+  for (const child of namedChildDrafts(state)) {
+    const grade = parseGrade(child.grade);
+    let created: IStudentListItem;
+    try {
+      created = await deps.createStudent({
+        name: child.name.trim(),
+        ...(grade != null ? { grade } : {}),
+      });
+    } catch (err: unknown) {
+      if (isPlanLimit(err) && students.length > 0) {
+        planLimitReached = true;
+        break;
+      }
+      throw err;
+    }
+    students.push(created);
+    const studentMongoId = created.id;
+    const studentExternalId = created.studentId ?? studentMongoId;
+    await deps.sources.upsert({
+      provider,
+      adapterId,
+      baseUrl: portalUrl,
+      sourceId: sourceIdForStudent(provider, institutionExternalId, studentMongoId),
+      credentialKey,
+      studentExternalId,
+      institutionExternalId,
+      studentId: studentMongoId,
+      adapterVersion: '0.1.0',
+    });
+    try {
+      await deps.registerIngestSource({
+        sourceId: sourceIdForStudent(provider, institutionExternalId, studentMongoId),
+        provider,
+        adapterId,
+        displayName: `${providerLabel(provider)} (${institutionExternalId})`,
+        portalBaseUrl: portalUrl,
+      });
+    } catch {
+      // Sync-time re-register heals this.
+    }
+  }
+
+  if (students.length === 0) {
+    throw new Error('Add at least one child');
+  }
+
+  return { students, planLimitReached };
+}
+
+function providerLabel(provider: OnboardingProvider): string {
+  if (provider === 'canvas') return 'Canvas LMS';
+  if (provider === 'skyward') return 'Skyward Family Access';
+  return 'Aeries Parent Portal';
+}

--- a/packages/mobile/src/onboarding/needsOnboarding.test.ts
+++ b/packages/mobile/src/onboarding/needsOnboarding.test.ts
@@ -1,0 +1,15 @@
+import { needsOnboarding } from './needsOnboarding';
+
+describe('needsOnboarding', () => {
+  it('is true when the parent is signed out', () => {
+    expect(needsOnboarding({ isLoggedIn: false, studentCount: 0 })).toBe(true);
+  });
+
+  it('is true when signed in with no students yet', () => {
+    expect(needsOnboarding({ isLoggedIn: true, studentCount: 0 })).toBe(true);
+  });
+
+  it('is false when the household already has a student', () => {
+    expect(needsOnboarding({ isLoggedIn: true, studentCount: 2 })).toBe(false);
+  });
+});

--- a/packages/mobile/src/onboarding/needsOnboarding.ts
+++ b/packages/mobile/src/onboarding/needsOnboarding.ts
@@ -1,0 +1,7 @@
+export function needsOnboarding(params: {
+  readonly isLoggedIn: boolean;
+  readonly studentCount: number;
+}): boolean {
+  if (!params.isLoggedIn) return true;
+  return params.studentCount === 0;
+}

--- a/packages/mobile/src/onboarding/onboardingMachine.test.ts
+++ b/packages/mobile/src/onboarding/onboardingMachine.test.ts
@@ -1,0 +1,96 @@
+import {
+  addChild,
+  canAdvance,
+  createInitialOnboardingState,
+  reduceOnboarding,
+  removeChild,
+  updateChild,
+} from './onboardingMachine';
+
+describe('onboardingMachine', () => {
+  it('starts at account for a logged-out first run', () => {
+    const state = createInitialOnboardingState('logged-out');
+    expect(state.step).toBe('account');
+    expect(state.accountMode).toBe('create');
+    expect(state.children).toHaveLength(1);
+  });
+
+  it('starts at children when the parent already has an account', () => {
+    expect(createInitialOnboardingState('logged-in').step).toBe('children');
+  });
+
+  it('blocks create-account advance without name, email, or an 8-char password', () => {
+    let state = createInitialOnboardingState('logged-out');
+    expect(canAdvance(state)).toBe(false);
+    state = reduceOnboarding(state, { type: 'set-parent-name', value: 'Ricardo' });
+    state = reduceOnboarding(state, { type: 'set-email', value: 'r@example.com' });
+    state = reduceOnboarding(state, { type: 'set-password', value: 'short' });
+    expect(canAdvance(state)).toBe(false);
+    state = reduceOnboarding(state, { type: 'set-password', value: 'password12' });
+    expect(canAdvance(state)).toBe(true);
+  });
+
+  it('requires at least one named child before leaving children', () => {
+    let state = createInitialOnboardingState('logged-in');
+    expect(canAdvance(state)).toBe(false);
+    state = updateChild(state, state.children[0]!.key, { name: 'Gideon' });
+    expect(canAdvance(state)).toBe(true);
+  });
+
+  it('adds a second child and will not remove the last remaining row', () => {
+    let state = createInitialOnboardingState('logged-in');
+    state = updateChild(state, state.children[0]!.key, { name: 'Gideon' });
+    state = addChild(state);
+    expect(state.children).toHaveLength(2);
+    state = updateChild(state, state.children[1]!.key, { name: 'Christian' });
+    state = removeChild(state, state.children[0]!.key);
+    expect(state.children).toHaveLength(1);
+    expect(state.children[0]?.name).toBe('Christian');
+    const same = removeChild(state, state.children[0]!.key);
+    expect(same.children).toHaveLength(1);
+  });
+
+  it('walks account → children → provider → portal-url → credentials', () => {
+    let state = createInitialOnboardingState('logged-out');
+    state = reduceOnboarding(state, { type: 'set-parent-name', value: 'Ricardo' });
+    state = reduceOnboarding(state, { type: 'set-email', value: 'r@example.com' });
+    state = reduceOnboarding(state, { type: 'set-password', value: 'password12' });
+    state = reduceOnboarding(state, { type: 'next' });
+    expect(state.step).toBe('children');
+    state = updateChild(state, state.children[0]!.key, { name: 'Gideon' });
+    state = reduceOnboarding(state, { type: 'next' });
+    expect(state.step).toBe('provider');
+    state = reduceOnboarding(state, { type: 'set-provider', provider: 'skyward' });
+    state = reduceOnboarding(state, { type: 'next' });
+    expect(state.step).toBe('portal-url');
+    state = reduceOnboarding(state, {
+      type: 'set-portal-url',
+      value: 'https://skyward.iscorp.com',
+    });
+    state = reduceOnboarding(state, { type: 'next' });
+    expect(state.step).toBe('credentials');
+    expect(canAdvance(state)).toBe(false);
+    state = reduceOnboarding(state, { type: 'set-username', value: 'parent' });
+    state = reduceOnboarding(state, { type: 'set-portal-password', value: 'secret' });
+    expect(canAdvance(state)).toBe(true);
+  });
+
+  it('rejects a portal URL without a hostname', () => {
+    let state = createInitialOnboardingState('logged-in');
+    state = updateChild(state, state.children[0]!.key, { name: 'Gideon' });
+    state = reduceOnboarding(state, { type: 'next' });
+    state = reduceOnboarding(state, { type: 'set-provider', provider: 'skyward' });
+    state = reduceOnboarding(state, { type: 'next' });
+    state = reduceOnboarding(state, { type: 'set-portal-url', value: 'not-a-url' });
+    expect(canAdvance(state)).toBe(false);
+  });
+
+  it('goes back without losing child names', () => {
+    let state = createInitialOnboardingState('logged-in');
+    state = updateChild(state, state.children[0]!.key, { name: 'Gideon' });
+    state = reduceOnboarding(state, { type: 'next' });
+    state = reduceOnboarding(state, { type: 'back' });
+    expect(state.step).toBe('children');
+    expect(state.children[0]?.name).toBe('Gideon');
+  });
+});

--- a/packages/mobile/src/onboarding/onboardingMachine.ts
+++ b/packages/mobile/src/onboarding/onboardingMachine.ts
@@ -1,0 +1,171 @@
+import { extractHostname } from '../utils/urlNormalize';
+
+export type OnboardingEntry = 'logged-out' | 'logged-in';
+
+export type OnboardingStep = 'account' | 'children' | 'provider' | 'portal-url' | 'credentials';
+
+export type OnboardingProvider = 'canvas' | 'skyward' | 'aeries';
+
+export type AccountMode = 'create' | 'signin';
+
+export interface IChildDraft {
+  readonly key: string;
+  readonly name: string;
+  readonly grade: string;
+}
+
+export interface IOnboardingState {
+  readonly entry: OnboardingEntry;
+  readonly step: OnboardingStep;
+  readonly accountMode: AccountMode;
+  readonly parentName: string;
+  readonly email: string;
+  readonly password: string;
+  readonly children: readonly IChildDraft[];
+  readonly provider: OnboardingProvider | null;
+  readonly portalUrl: string;
+  readonly username: string;
+  readonly portalPassword: string;
+  readonly nextChildKey: number;
+}
+
+export type OnboardingAction =
+  | { readonly type: 'set-account-mode'; readonly mode: AccountMode }
+  | { readonly type: 'set-parent-name'; readonly value: string }
+  | { readonly type: 'set-email'; readonly value: string }
+  | { readonly type: 'set-password'; readonly value: string }
+  | { readonly type: 'set-provider'; readonly provider: OnboardingProvider }
+  | { readonly type: 'set-portal-url'; readonly value: string }
+  | { readonly type: 'set-username'; readonly value: string }
+  | { readonly type: 'set-portal-password'; readonly value: string }
+  | { readonly type: 'next' }
+  | { readonly type: 'back' };
+
+const STEP_ORDER: readonly OnboardingStep[] = [
+  'account',
+  'children',
+  'provider',
+  'portal-url',
+  'credentials',
+];
+
+function newChild(key: string): IChildDraft {
+  return { key, name: '', grade: '' };
+}
+
+export function createInitialOnboardingState(entry: OnboardingEntry): IOnboardingState {
+  return {
+    entry,
+    step: entry === 'logged-out' ? 'account' : 'children',
+    accountMode: 'create',
+    parentName: '',
+    email: '',
+    password: '',
+    children: [newChild('c1')],
+    provider: null,
+    portalUrl: '',
+    username: '',
+    portalPassword: '',
+    nextChildKey: 2,
+  };
+}
+
+function namedChildren(state: IOnboardingState): readonly IChildDraft[] {
+  return state.children.filter((c) => c.name.trim().length > 0);
+}
+
+export function canAdvance(state: IOnboardingState): boolean {
+  switch (state.step) {
+    case 'account':
+      if (state.accountMode === 'signin') {
+        return state.email.trim().length > 0 && state.password.length > 0;
+      }
+      return (
+        state.parentName.trim().length > 0 &&
+        state.email.trim().length > 0 &&
+        state.password.length >= 8
+      );
+    case 'children':
+      return namedChildren(state).length > 0;
+    case 'provider':
+      return state.provider != null;
+    case 'portal-url':
+      return extractHostname(state.portalUrl.trim()) !== '';
+    case 'credentials':
+      return state.username.trim().length > 0 && state.portalPassword.length > 0;
+    default:
+      return false;
+  }
+}
+
+function stepIndex(step: OnboardingStep): number {
+  return STEP_ORDER.indexOf(step);
+}
+
+export function reduceOnboarding(
+  state: IOnboardingState,
+  action: OnboardingAction
+): IOnboardingState {
+  switch (action.type) {
+    case 'set-account-mode':
+      return { ...state, accountMode: action.mode };
+    case 'set-parent-name':
+      return { ...state, parentName: action.value };
+    case 'set-email':
+      return { ...state, email: action.value };
+    case 'set-password':
+      return { ...state, password: action.value };
+    case 'set-provider':
+      return { ...state, provider: action.provider };
+    case 'set-portal-url':
+      return { ...state, portalUrl: action.value };
+    case 'set-username':
+      return { ...state, username: action.value };
+    case 'set-portal-password':
+      return { ...state, portalPassword: action.value };
+    case 'next': {
+      if (!canAdvance(state)) return state;
+      const idx = stepIndex(state.step);
+      const next = STEP_ORDER[idx + 1];
+      return next ? { ...state, step: next } : state;
+    }
+    case 'back': {
+      const idx = stepIndex(state.step);
+      if (idx <= 0) return state;
+      if (state.entry === 'logged-in' && state.step === 'children') return state;
+      const prev = STEP_ORDER[idx - 1];
+      return prev ? { ...state, step: prev } : state;
+    }
+    default:
+      return state;
+  }
+}
+
+export function addChild(state: IOnboardingState): IOnboardingState {
+  const key = `c${state.nextChildKey}`;
+  return {
+    ...state,
+    children: [...state.children, newChild(key)],
+    nextChildKey: state.nextChildKey + 1,
+  };
+}
+
+export function removeChild(state: IOnboardingState, key: string): IOnboardingState {
+  if (state.children.length <= 1) return state;
+  return { ...state, children: state.children.filter((c) => c.key !== key) };
+}
+
+export function updateChild(
+  state: IOnboardingState,
+  key: string,
+  patch: Partial<Pick<IChildDraft, 'name' | 'grade'>>
+): IOnboardingState {
+  return {
+    ...state,
+    children: state.children.map((c) => (c.key === key ? { ...c, ...patch } : c)),
+  };
+}
+
+export function namedChildDrafts(state: IOnboardingState): readonly IChildDraft[] {
+  return namedChildren(state);
+}

--- a/packages/mobile/src/screens/ConnectSourceScreen.tsx
+++ b/packages/mobile/src/screens/ConnectSourceScreen.tsx
@@ -22,9 +22,10 @@ import {
 } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 import {
-  connectedSourceStore,
-  buildCredentialKey,
   ADAPTER_IDS,
+  buildCredentialKey,
+  connectedSourceStore,
+  sourceIdForStudent,
 } from '../sources/ConnectedSourceStore';
 import { apiClient } from '../api/client';
 import { extractHostname } from '../utils/urlNormalize';
@@ -122,6 +123,17 @@ export function ConnectSourceScreen({
       return;
     }
 
+    const institutionExternalId = extractHostname(portalUrl);
+    const mongoId = invite?.studentId ?? studentId;
+    const externalId = invite?.studentExternalId ?? studentExternalId ?? mongoId;
+    if (!externalId) {
+      Alert.alert(
+        'Add a student first',
+        'Create a child profile before connecting a school portal.'
+      );
+      return;
+    }
+
     setIsSaving(true);
     try {
       const credential: ISavedCredential = {
@@ -138,8 +150,9 @@ export function ConnectSourceScreen({
         keychainAccessible: SecureStore.WHEN_UNLOCKED,
       });
 
-      const institutionExternalId = extractHostname(portalUrl);
-      const sourceId = `local-${selectedProvider.id}-${institutionExternalId}`;
+      const sourceId = mongoId
+        ? sourceIdForStudent(selectedProvider.id, institutionExternalId, mongoId)
+        : `local-${selectedProvider.id}-${institutionExternalId}`;
       const adapterId = ADAPTER_IDS[selectedProvider.id] ?? `com.${selectedProvider.id}`;
       await connectedSourceStore.upsert({
         provider: selectedProvider.id,
@@ -147,9 +160,9 @@ export function ConnectSourceScreen({
         baseUrl: portalUrl,
         sourceId,
         credentialKey: key,
-        studentExternalId: invite?.studentExternalId ?? studentExternalId ?? 'default',
+        studentExternalId: externalId,
         institutionExternalId,
-        studentId: invite?.studentId ?? studentId,
+        studentId: mongoId,
         adapterVersion: '0.1.0',
       });
 

--- a/packages/mobile/src/screens/StudentsScreen.tsx
+++ b/packages/mobile/src/screens/StudentsScreen.tsx
@@ -17,12 +17,14 @@ import { apiClient, type IStudentListItem } from '../api/client';
 interface IStudentsScreenProps {
   onSelectStudent(student: IStudentListItem): void;
   onAddSource(): void;
+  onStartSetup?(): void;
   onOpenSettings?(): void;
 }
 
 export function StudentsScreen({
   onSelectStudent,
   onAddSource,
+  onStartSetup,
   onOpenSettings,
 }: IStudentsScreenProps): React.ReactElement {
   const [students, setStudents] = useState<IStudentListItem[]>([]);
@@ -120,9 +122,11 @@ export function StudentsScreen({
           ) : (
             <View style={styles.empty}>
               <Text style={styles.emptyTitle}>No students yet</Text>
-              <Text style={styles.emptyText}>Connect a school portal to start syncing data.</Text>
-              <TouchableOpacity style={styles.emptyButton} onPress={onAddSource}>
-                <Text style={styles.emptyButtonText}>Connect Portal</Text>
+              <Text style={styles.emptyText}>
+                Add your kids and connect the school portal. It takes a few minutes.
+              </Text>
+              <TouchableOpacity style={styles.emptyButton} onPress={onStartSetup ?? onAddSource}>
+                <Text style={styles.emptyButtonText}>Get started</Text>
               </TouchableOpacity>
             </View>
           )

--- a/packages/mobile/src/sources/ConnectedSourceStore.test.ts
+++ b/packages/mobile/src/sources/ConnectedSourceStore.test.ts
@@ -6,6 +6,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   ConnectedSourceStore,
   buildCredentialKey,
+  sourceIdForStudent,
   type IConnectedSource,
 } from './ConnectedSourceStore';
 
@@ -54,6 +55,25 @@ describe('ConnectedSourceStore', () => {
     await store.upsert(makeSource({ studentExternalId: 'stu-b', sourceId: 'b' }));
     const found = await store.getForStudent('stu-b');
     expect(found?.sourceId).toBe('b');
+  });
+
+  it('should match a household student by mongo id when SIS id is not set yet', async () => {
+    await store.upsert(
+      makeSource({
+        sourceId: 'local-skyward-host-mongo-g',
+        studentId: 'mongo-g',
+        studentExternalId: 'mongo-g',
+      })
+    );
+    const found = await store.getForStudentRecord({ id: 'mongo-g' });
+    expect(found?.sourceId).toBe('local-skyward-host-mongo-g');
+  });
+
+  it('should build a per-student source id so two kids sharing a portal do not clobber', () => {
+    const a = sourceIdForStudent('skyward', 'skyward.iscorp.com', 'mongo-g');
+    const b = sourceIdForStudent('skyward', 'skyward.iscorp.com', 'mongo-c');
+    expect(a).not.toBe(b);
+    expect(a).toContain('mongo-g');
   });
 
   it('should return null for an unknown student instead of falling back to another source', async () => {

--- a/packages/mobile/src/sources/ConnectedSourceStore.ts
+++ b/packages/mobile/src/sources/ConnectedSourceStore.ts
@@ -22,6 +22,10 @@ export interface IConnectedSource {
 export interface IConnectedSourceStore {
   list(): Promise<readonly IConnectedSource[]>;
   getForStudent(studentExternalId: string): Promise<IConnectedSource | null>;
+  getForStudentRecord(student: {
+    readonly id: string;
+    readonly studentId?: string;
+  }): Promise<IConnectedSource | null>;
   upsert(source: IConnectedSource): Promise<void>;
   remove(sourceId: string): Promise<void>;
 }
@@ -42,6 +46,19 @@ export class ConnectedSourceStore implements IConnectedSourceStore {
     // No fallback to another student's source: syncing the wrong portal is
     // worse than prompting the user to connect one.
     return all.find((s) => s.studentExternalId === studentExternalId) ?? null;
+  }
+
+  async getForStudentRecord(student: {
+    readonly id: string;
+    readonly studentId?: string;
+  }): Promise<IConnectedSource | null> {
+    const all = await this.list();
+    return (
+      all.find((s) => s.studentId === student.id) ??
+      (student.studentId
+        ? (all.find((s) => s.studentExternalId === student.studentId) ?? null)
+        : null)
+    );
   }
 
   async upsert(source: IConnectedSource): Promise<void> {
@@ -65,6 +82,14 @@ export const ADAPTER_IDS: Record<string, string> = {
   skyward: 'com.skyward.iscorp',
   aeries: 'com.aeries.portal',
 };
+
+export function sourceIdForStudent(
+  provider: string,
+  institutionExternalId: string,
+  studentMongoId: string
+): string {
+  return `local-${provider}-${institutionExternalId}-${studentMongoId}`;
+}
 
 export function buildCredentialKey(provider: string, baseUrl: string): string {
   const domain = baseUrl.replace(/https?:\/\//, '').replace(/\/$/, '');


### PR DESCRIPTION
## Summary
- New parents can create an account, add children, save portal credentials on-device, and run a first sync without going to the website first.
- Shared Keychain credentials and unique source IDs per child; invite deep links still win when present.

## Test plan
- [ ] Quality Gate (lint/type-check/tests) green
- [ ] Docker pre-deploy images (api, web, workers) succeed
- [ ] After merge, Railway `dev` `/api/health/version` matches the squash SHA
- [ ] Preview + production EAS OTAs publish from the merged SHA


Made with [Cursor](https://cursor.com)